### PR TITLE
Enabling users to set line spacing for multi-line labels

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -55,7 +55,8 @@ class Label(displayio.Group):
        :param int max_glyphs: The largest quantity of glyphs we will display
        :param int color: Color of all text in RGB hex
        :param double line_spacing: Line spacing of text to display"""
-    def __init__(self, font, *, text=None, max_glyphs=None, color=0xffffff, line_spacing=1.25, **kwargs):
+    def __init__(self, font, *, text=None, max_glyphs=None, color=0xffffff,
+                 line_spacing=1.25, **kwargs):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
         if not max_glyphs:

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -53,8 +53,9 @@ class Label(displayio.Group):
        :param Font font: A font class that has ``get_bounding_box`` and ``get_glyph``
        :param str text: Text to display
        :param int max_glyphs: The largest quantity of glyphs we will display
-       :param int color: Color of all text in RGB hex"""
-    def __init__(self, font, *, text=None, max_glyphs=None, color=0xffffff, **kwargs):
+       :param int color: Color of all text in RGB hex
+       :param double line_spacing: Line spacing of text to display"""
+    def __init__(self, font, *, text=None, max_glyphs=None, color=0xffffff, line_spacing=1.25, **kwargs):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
         if not max_glyphs:
@@ -70,7 +71,7 @@ class Label(displayio.Group):
 
         bounds = self.font.get_bounding_box()
         self.height = bounds[1]
-        self._line_spacing = 1.25
+        self._line_spacing = line_spacing
         self._boundingbox = None
 
         if text:


### PR DESCRIPTION
Greetings. Regarding the part of [PyPortal set_text speed (and line-spacing)?](
https://forums.adafruit.com/viewtopic.php?f=60&t=148356) about the default line spacing for multi-line text, I managed to override the `_line_spacing` property on my text area to a much denser value.

The image below shows the result of the tighter spacing.
![IMG_3346](https://user-images.githubusercontent.com/1451881/54874135-5f9b2a80-4db3-11e9-9643-9cd961dee306.jpg)

Making a PR to allow users to set their own line spacing without using private properties, and keeping the default line spacing of 1.25. Thanks for any feedback.