### PR TITLE
Update simple example and usage example in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,11 +36,13 @@ For a board with a built-in display.
     import terminalio
     from adafruit_display_text import label
 
+
     text = "Hello world"
     text_area = label.Label(terminalio.FONT, text=text)
     text_area.x = 10
     text_area.y = 10
-    board.DISPLAY.show(text_area)
+    while True:
+        board.DISPLAY.show(text_area)
 
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,9 @@ For a board with a built-in display.
     text_area = label.Label(terminalio.FONT, text=text)
     text_area.x = 10
     text_area.y = 10
+    board.DISPLAY.show(text_area)
     while True:
-        board.DISPLAY.show(text_area)
+        pass
 
 
 Contributing

--- a/examples/display_text_simpletest.py
+++ b/examples/display_text_simpletest.py
@@ -7,5 +7,6 @@ text = "Hello world"
 text_area = label.Label(terminalio.FONT, text=text)
 text_area.x = 10
 text_area.y = 10
+board.DISPLAY.show(text_area)
 while True:
-    board.DISPLAY.show(text_area)
+    pass

--- a/examples/display_text_simpletest.py
+++ b/examples/display_text_simpletest.py
@@ -1,0 +1,11 @@
+import board
+import terminalio
+from adafruit_display_text import label
+
+
+text = "Hello world"
+text_area = label.Label(terminalio.FONT, text=text)
+text_area.x = 10
+text_area.y = 10
+while True:
+    board.DISPLAY.show(text_area)


### PR DESCRIPTION
Update simple example and usage example in readme, additional line after imports for pep 8.

As mentioned in #15 the simplest test example was blank although there was a good example in the readme file. I update the simple test file to match the usage example in the readme file and also put the display updating call in a `while True:` loop so a user will be sure to see the output.

I also added an additional blank line after the import statements in that file for pep 8 compliance. I also then copied that code to the usage example in the readme so that the update is reflected there.

I built the docs to verify the changes were reflected there, they were and I saw no other relevant aspect of the docs that needed updating. Even though the simple test file was blank the docs were already pointing to it, probably because there are so many of these wonderful libraries. 😄 

If the pep 8 line is not welcome I can remove that and resubmit.