### PR TITLE
Added properties "cx" and "cy" to use the center of the label as position 

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -175,16 +175,18 @@ class Label(displayio.Group):
 
     @property
     def cx(self):
+        """Center X of the Label """
         return self.x + self._boundingbox[2]/2
 
     @property 
     def cy(self):
+         """Center Y of the Label """
         return self.y + self._boundingbox[3]/2
 
     @cx.setter
-    def cx(self,new_cx):
+    def cx(self, new_cx):
         self.x = int(new_cx-(self._boundingbox[2]/2))
 
     @cy.setter
-    def cy(self,new_cy):
+    def cy(self, new_cy):
         self.y = int(new_cy-(self._boundingbox[3]/2))

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -74,6 +74,8 @@ class Label(displayio.Group):
         self.height = bounds[1]
         self._line_spacing = line_spacing
         self._boundingbox = None
+        self._cx = None
+        self._cy = None
 
         if text:
             self._update_text(text)
@@ -172,3 +174,19 @@ class Label(displayio.Group):
     @text.setter
     def text(self, new_text):
         self._update_text(new_text)
+
+    @property
+    def cx(self):
+        return self.x + self._boundingbox[2]
+
+    @property 
+    def cy(self):
+        return self.y + self._boundingbox[3]
+
+    @cx.setter
+    def cx(self,new_cx):
+        self.x = int(new_cx-(self._boundingbox[2]/2))
+
+    @cy.setter
+    def cy(self,new_cy):
+        self.y = int(new_cy-(self._boundingbox[3]/2))

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -74,8 +74,6 @@ class Label(displayio.Group):
         self.height = bounds[1]
         self._line_spacing = line_spacing
         self._boundingbox = None
-        self._cx = None
-        self._cy = None
 
         if text:
             self._update_text(text)
@@ -177,11 +175,11 @@ class Label(displayio.Group):
 
     @property
     def cx(self):
-        return self.x + self._boundingbox[2]
+        return self.x + self._boundingbox[2]/2
 
     @property 
     def cy(self):
-        return self.y + self._boundingbox[3]
+        return self.y + self._boundingbox[3]/2
 
     @cx.setter
     def cx(self,new_cx):


### PR DESCRIPTION
I have added "cx" and "cy" property to the label, such that setting those will move the center of the text rather than the top left corner of the text. My apologies if it is already available. 

Eg. for PyPortal 
```python
timeDisplay = label.Label(font,text='12:60:60',color=color)
timeDisplay.cx = 160 
timeDisplay.cy = 120
```