### PR TITLE
Added "cx" and "cy" property to the label to change center of Label

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -175,16 +175,18 @@ class Label(displayio.Group):
 
     @property
     def cx(self):
+        """Center X of the Label """
         return self.x + self._boundingbox[2]/2
 
     @property 
     def cy(self):
+         """Center Y of the Label """
         return self.y + self._boundingbox[3]/2
 
     @cx.setter
-    def cx(self,new_cx):
+    def cx(self, new_cx):
         self.x = int(new_cx-(self._boundingbox[2]/2))
 
     @cy.setter
-    def cy(self,new_cy):
+    def cy(self, new_cy):
         self.y = int(new_cy-(self._boundingbox[3]/2))

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -65,7 +65,8 @@ class Label(displayio.Group):
         self.width = max_glyphs
         self.font = font
         self._text = None
-
+        self._anchor_point = (0, 0)
+        
         self.palette = displayio.Palette(2)
         self.palette.make_transparent(0)
         self.palette[1] = color

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -174,19 +174,26 @@ class Label(displayio.Group):
         self._update_text(new_text)
 
     @property
-    def cx(self):
-        """Center X of the Label """
-        return self.x + self._boundingbox[2]/2
+    def anchor_point(self):
+        """Point that anchored_position moves relative to.
+           Tuple with decimal percentage of width and height.
+           (E.g. (0,0) is top left, (1.0, 0.5): is middle right.)"""
+        return self._anchor_point
 
-    @property 
-    def cy(self):
-         """Center Y of the Label """
-         return self.y + self._boundingbox[3]/2
+    @anchor_point.setter
+    def anchor_point(self, new_anchor_point):
+        self._anchor_point = new_anchor_point
 
-    @cx.setter
-    def cx(self, new_cx):
-        self.x = int(new_cx-(self._boundingbox[2]/2))
+    @property
+    def anchored_position(self):
+        """Position relative to the anchor_point. Tuple containing x,y
+           pixel coordinates."""
+        _anchored_position = (
+            self.x-self._boundingbox[2]*self._anchor_point[0],
+            self.y-self._boundingbox[3]*self._anchor_point[1])
+        return _anchored_position
 
-    @cy.setter
-    def cy(self, new_cy):
-        self.y = int(new_cy-(self._boundingbox[3]/2))
+    @anchored_position.setter
+    def anchored_position(self, new_position):
+        self.x = int(new_position[0]-(self._boundingbox[2]*self._anchor_point[0]))
+        self.y = int(new_position[1]-(self._boundingbox[3]*self._anchor_point[1]))

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -65,7 +65,7 @@ class Label(displayio.Group):
         self.width = max_glyphs
         self.font = font
         self._text = None
-        
+
         self.palette = displayio.Palette(2)
         self.palette.make_transparent(0)
         self.palette[1] = color

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -74,6 +74,8 @@ class Label(displayio.Group):
         self.height = bounds[1]
         self._line_spacing = line_spacing
         self._boundingbox = None
+        self._cx = None
+        self._cy = None
 
         if text:
             self._update_text(text)
@@ -172,3 +174,19 @@ class Label(displayio.Group):
     @text.setter
     def text(self, new_text):
         self._update_text(new_text)
+
+    @property
+    def cx(self):
+        return self.x + self._boundingbox[2]
+
+    @property 
+    def cy(self):
+        return self.y + self._boundingbox[3]
+
+    @cx.setter
+    def cx(self,new_cx):
+        self.x = int(new_cx-(self._boundingbox[2]/2))
+
+    @cy.setter
+    def cy(self,new_cy):
+        self.y = int(new_cy-(self._boundingbox[3]/2))

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -66,6 +66,8 @@ class Label(displayio.Group):
         self.font = font
         self._text = None
         self._anchor_point = (0, 0)
+        self.x = 0
+        self.y = 0
 
         self.palette = displayio.Palette(2)
         self.palette.make_transparent(0)

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -181,7 +181,7 @@ class Label(displayio.Group):
     @property 
     def cy(self):
          """Center Y of the Label """
-        return self.y + self._boundingbox[3]/2
+         return self.y + self._boundingbox[3]/2
 
     @cx.setter
     def cx(self, new_cx):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -65,7 +65,6 @@ class Label(displayio.Group):
         self.width = max_glyphs
         self.font = font
         self._text = None
-        self._anchor_point = (0, 0)
         
         self.palette = displayio.Palette(2)
         self.palette.make_transparent(0)
@@ -189,10 +188,8 @@ class Label(displayio.Group):
     def anchored_position(self):
         """Position relative to the anchor_point. Tuple containing x,y
            pixel coordinates."""
-        _anchored_position = (
-            self.x-self._boundingbox[2]*self._anchor_point[0],
-            self.y-self._boundingbox[3]*self._anchor_point[1])
-        return _anchored_position
+        return (self.x-self._boundingbox[2]*self._anchor_point[0],
+                self.y-self._boundingbox[3]*self._anchor_point[1])
 
     @anchored_position.setter
     def anchored_position(self, new_position):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -74,8 +74,6 @@ class Label(displayio.Group):
         self.height = bounds[1]
         self._line_spacing = line_spacing
         self._boundingbox = None
-        self._cx = None
-        self._cy = None
 
         if text:
             self._update_text(text)
@@ -177,11 +175,11 @@ class Label(displayio.Group):
 
     @property
     def cx(self):
-        return self.x + self._boundingbox[2]
+        return self.x + self._boundingbox[2]/2
 
     @property 
     def cy(self):
-        return self.y + self._boundingbox[3]
+        return self.y + self._boundingbox[3]/2
 
     @cx.setter
     def cx(self,new_cx):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -65,6 +65,7 @@ class Label(displayio.Group):
         self.width = max_glyphs
         self.font = font
         self._text = None
+        self._anchor_point = (0, 0)
 
         self.palette = displayio.Palette(2)
         self.palette.make_transparent(0)


### PR DESCRIPTION
I have added "cx" and "cy" property to the label, such that setting those will move the center of the text rather than the top left corner of the text. My apologies if it is already available. 

Eg. for PyPortal 
```python
timeDisplay = label.Label(font,text='12:60:60',color=color)
timeDisplay.cx = 160 
timeDisplay.cy = 120
```