### PR TITLE
Convert text object to string.

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -80,7 +80,7 @@ class Label(displayio.Group):
         self._boundingbox = None
 
         if text:
-            self._update_text(text)
+            self._update_text(str(text))
 
 
     def _update_text(self, new_text): # pylint: disable=too-many-locals
@@ -175,7 +175,7 @@ class Label(displayio.Group):
 
     @text.setter
     def text(self, new_text):
-        self._update_text(new_text)
+        self._update_text(str(new_text))
 
     @property
     def anchor_point(self):


### PR DESCRIPTION
Allows for providing float object, such as acceleration or gyro data, without needing to convert to string in user code.