### PR TITLE
Fixes issue where label will not display when value is False

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -79,7 +79,7 @@ class Label(displayio.Group):
         self._line_spacing = line_spacing
         self._boundingbox = None
 
-        if text:
+        if text is not None:
             self._update_text(str(text))
 
 


### PR DESCRIPTION
Resolves issue where text value evaluates to False, label will not display.

Tested with proximity data that returns 0 when no object is present.