### PR TITLE
Added x and y as keyword arguments.

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -67,8 +67,8 @@ class Label(displayio.Group):
         self.font = font
         self._text = None
         self._anchor_point = (0, 0)
-        self.x = x 
-        self.y = y 
+        self.x = x
+        self.y = y
 
         self.palette = displayio.Palette(2)
         self.palette.make_transparent(0)

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -56,7 +56,7 @@ class Label(displayio.Group):
        :param int max_glyphs: The largest quantity of glyphs we will display
        :param int color: Color of all text in RGB hex
        :param double line_spacing: Line spacing of text to display"""
-    def __init__(self, font, *, text=None, max_glyphs=None, color=0xffffff,
+    def __init__(self, font, *, x=0, y=0, text=None, max_glyphs=None, color=0xffffff,
                  line_spacing=1.25, **kwargs):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
@@ -67,8 +67,8 @@ class Label(displayio.Group):
         self.font = font
         self._text = None
         self._anchor_point = (0, 0)
-        self.x = 0
-        self.y = 0
+        self.x = x 
+        self.y = y 
 
         self.palette = displayio.Palette(2)
         self.palette.make_transparent(0)


### PR DESCRIPTION
This fixes an issue when assigning x and y when initializing a Label instance that caused x and y to go to 0.