### PR TITLE
Adding background_color

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -72,7 +72,7 @@ class Label(displayio.Group):
 
         self.palette = displayio.Palette(2)
         if background_color or background_color == 0x000000:
-            self.palette[0] = new_color
+            self.palette[0] = background_color
             self.palette.make_opaque(0)
             self._transparent_background = False
         else:

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -44,7 +44,6 @@ import displayio
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
 
-
 class Label(displayio.Group):
     """A label displaying a string of text. The origin point set by ``x`` and ``y``
        properties will be the left edge of the bounding box, and in the center of a M
@@ -57,7 +56,6 @@ class Label(displayio.Group):
        :param int max_glyphs: The largest quantity of glyphs we will display
        :param int color: Color of all text in RGB hex
        :param double line_spacing: Line spacing of text to display"""
-
     def __init__(self, font, *, x=0, y=0, text=None, max_glyphs=None, color=0xffffff,
                  backgroud_color=False, line_spacing=1.25, **kwargs):
         if not max_glyphs and not text:
@@ -87,14 +85,15 @@ class Label(displayio.Group):
         if text is not None:
             self._update_text(str(text))
 
-    def _update_text(self, new_text):  # pylint: disable=too-many-locals
+
+    def _update_text(self, new_text): # pylint: disable=too-many-locals
         x = 0
         y = 0
         i = 0
         old_c = 0
         y_offset = int((self.font.get_glyph(ord('M')).height -
                         new_text.count('\n') * self.height * self.line_spacing) / 2)
-        # print("y offset from baseline", y_offset)
+        #print("y offset from baseline", y_offset)
         left = right = top = bottom = 0
         for character in new_text:
             if character == '\n':
@@ -104,10 +103,10 @@ class Label(displayio.Group):
             glyph = self.font.get_glyph(ord(character))
             if not glyph:
                 continue
-            right = max(right, x + glyph.width)
-            if y == 0:  # first line, find the Ascender height
-                top = min(top, -glyph.height + y_offset)
-            bottom = max(bottom, y - glyph.dy + y_offset)
+            right = max(right, x+glyph.width)
+            if y == 0:   # first line, find the Ascender height
+                top = min(top, -glyph.height+y_offset)
+            bottom = max(bottom, y-glyph.dy+y_offset)
             position_y = y - glyph.height - glyph.dy + y_offset
             position_x = x + glyph.dx
             if not self._text or old_c >= len(self._text) or character != self._text[old_c]:
@@ -145,7 +144,7 @@ class Label(displayio.Group):
         while len(self) > i:
             self.pop()
         self._text = new_text
-        self._boundingbox = (left, top, left + right, bottom - top)
+        self._boundingbox = (left, top, left+right, bottom-top)
 
     @property
     def bounding_box(self):
@@ -196,10 +195,10 @@ class Label(displayio.Group):
     def anchored_position(self):
         """Position relative to the anchor_point. Tuple containing x,y
            pixel coordinates."""
-        return (self.x - self._boundingbox[2] * self._anchor_point[0],
-                self.y - self._boundingbox[3] * self._anchor_point[1])
+        return (self.x-self._boundingbox[2]*self._anchor_point[0],
+                self.y-self._boundingbox[3]*self._anchor_point[1])
 
     @anchored_position.setter
     def anchored_position(self, new_position):
-        self.x = int(new_position[0] - (self._boundingbox[2] * self._anchor_point[0]))
-        self.y = int(new_position[1] - (self._boundingbox[3] * self._anchor_point[1]))
+        self.x = int(new_position[0]-(self._boundingbox[2]*self._anchor_point[0]))
+        self.y = int(new_position[1]-(self._boundingbox[3]*self._anchor_point[1]))

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -71,7 +71,7 @@ class Label(displayio.Group):
         self.y = y
 
         self.palette = displayio.Palette(2)
-        if background_color or background_color == 0x000000:
+        if background_color is not None:
             self.palette[0] = background_color
             self.palette.make_opaque(0)
             self._transparent_background = False
@@ -184,7 +184,7 @@ class Label(displayio.Group):
 
     @background_color.setter
     def background_color(self, new_color):
-        if new_color or new_color == 0x000000:
+        if new_color is not None:
             self.palette[0] = new_color
             self.palette.make_opaque(0)
             self._transparent_background = False

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -178,8 +178,7 @@ class Label(displayio.Group):
         """Color of the background as an RGB hex number."""
         if not self.transparent_background:
             return self.palette[0]
-        else:
-            return None
+        return None
 
     @background_color.setter
     def background_color(self, new_color):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -57,7 +57,7 @@ class Label(displayio.Group):
        :param int color: Color of all text in RGB hex
        :param double line_spacing: Line spacing of text to display"""
     def __init__(self, font, *, x=0, y=0, text=None, max_glyphs=None, color=0xffffff,
-                 background_color=False, line_spacing=1.25, **kwargs):
+                 background_color=None, line_spacing=1.25, **kwargs):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
         if not max_glyphs:
@@ -72,8 +72,10 @@ class Label(displayio.Group):
 
         self.palette = displayio.Palette(2)
         if not background_color:
+            self.transparent_background = True
             self.palette.make_transparent(0)
         else:
+            self.transparent_background = False
             self.palette[0] = background_color
         self.palette[1] = color
 
@@ -174,15 +176,21 @@ class Label(displayio.Group):
     @property
     def background_color(self):
         """Color of the background as an RGB hex number."""
-        return self.palette[0]
+        if not self.transparent_background:
+            return self.palette[0]
+        else:
+            return None
 
     @background_color.setter
     def background_color(self, new_color):
         if new_color:
             self.palette[0] = new_color
             self.palette.make_opaque(0)
+            self.transparent_background = False
         else:
+            self.palette[0] = 0
             self.palette.make_transparent(0)
+            self.transparent_background = True
 
     @property
     def text(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -44,6 +44,7 @@ import displayio
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
 
+
 class Label(displayio.Group):
     """A label displaying a string of text. The origin point set by ``x`` and ``y``
        properties will be the left edge of the bounding box, and in the center of a M
@@ -56,8 +57,9 @@ class Label(displayio.Group):
        :param int max_glyphs: The largest quantity of glyphs we will display
        :param int color: Color of all text in RGB hex
        :param double line_spacing: Line spacing of text to display"""
+
     def __init__(self, font, *, x=0, y=0, text=None, max_glyphs=None, color=0xffffff,
-                 line_spacing=1.25, **kwargs):
+                 backgroud_color=False, line_spacing=1.25, **kwargs):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
         if not max_glyphs:
@@ -71,7 +73,10 @@ class Label(displayio.Group):
         self.y = y
 
         self.palette = displayio.Palette(2)
-        self.palette.make_transparent(0)
+        if not backgroud_color:
+            self.palette.make_transparent(0)
+        else:
+            self.palette[0] = backgroud_color
         self.palette[1] = color
 
         bounds = self.font.get_bounding_box()
@@ -82,15 +87,14 @@ class Label(displayio.Group):
         if text is not None:
             self._update_text(str(text))
 
-
-    def _update_text(self, new_text): # pylint: disable=too-many-locals
+    def _update_text(self, new_text):  # pylint: disable=too-many-locals
         x = 0
         y = 0
         i = 0
         old_c = 0
         y_offset = int((self.font.get_glyph(ord('M')).height -
                         new_text.count('\n') * self.height * self.line_spacing) / 2)
-        #print("y offset from baseline", y_offset)
+        # print("y offset from baseline", y_offset)
         left = right = top = bottom = 0
         for character in new_text:
             if character == '\n':
@@ -100,10 +104,10 @@ class Label(displayio.Group):
             glyph = self.font.get_glyph(ord(character))
             if not glyph:
                 continue
-            right = max(right, x+glyph.width)
-            if y == 0:   # first line, find the Ascender height
-                top = min(top, -glyph.height+y_offset)
-            bottom = max(bottom, y-glyph.dy+y_offset)
+            right = max(right, x + glyph.width)
+            if y == 0:  # first line, find the Ascender height
+                top = min(top, -glyph.height + y_offset)
+            bottom = max(bottom, y - glyph.dy + y_offset)
             position_y = y - glyph.height - glyph.dy + y_offset
             position_x = x + glyph.dx
             if not self._text or old_c >= len(self._text) or character != self._text[old_c]:
@@ -141,7 +145,7 @@ class Label(displayio.Group):
         while len(self) > i:
             self.pop()
         self._text = new_text
-        self._boundingbox = (left, top, left+right, bottom-top)
+        self._boundingbox = (left, top, left + right, bottom - top)
 
     @property
     def bounding_box(self):
@@ -192,10 +196,10 @@ class Label(displayio.Group):
     def anchored_position(self):
         """Position relative to the anchor_point. Tuple containing x,y
            pixel coordinates."""
-        return (self.x-self._boundingbox[2]*self._anchor_point[0],
-                self.y-self._boundingbox[3]*self._anchor_point[1])
+        return (self.x - self._boundingbox[2] * self._anchor_point[0],
+                self.y - self._boundingbox[3] * self._anchor_point[1])
 
     @anchored_position.setter
     def anchored_position(self, new_position):
-        self.x = int(new_position[0]-(self._boundingbox[2]*self._anchor_point[0]))
-        self.y = int(new_position[1]-(self._boundingbox[3]*self._anchor_point[1]))
+        self.x = int(new_position[0] - (self._boundingbox[2] * self._anchor_point[0]))
+        self.y = int(new_position[1] - (self._boundingbox[3] * self._anchor_point[1]))

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -57,7 +57,7 @@ class Label(displayio.Group):
        :param int color: Color of all text in RGB hex
        :param double line_spacing: Line spacing of text to display"""
     def __init__(self, font, *, x=0, y=0, text=None, max_glyphs=None, color=0xffffff,
-                 backgroud_color=False, line_spacing=1.25, **kwargs):
+                 background_color=False, line_spacing=1.25, **kwargs):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
         if not max_glyphs:
@@ -71,10 +71,10 @@ class Label(displayio.Group):
         self.y = y
 
         self.palette = displayio.Palette(2)
-        if not backgroud_color:
+        if not background_color:
             self.palette.make_transparent(0)
         else:
-            self.palette[0] = backgroud_color
+            self.palette[0] = background_color
         self.palette[1] = color
 
         bounds = self.font.get_bounding_box()

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -182,7 +182,7 @@ class Label(displayio.Group):
 
     @background_color.setter
     def background_color(self, new_color):
-        if new_color:
+        if new_color or new_color == 0x000000:
             self.palette[0] = new_color
             self.palette.make_opaque(0)
             self.transparent_background = False

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -72,10 +72,10 @@ class Label(displayio.Group):
 
         self.palette = displayio.Palette(2)
         if not background_color:
-            self.transparent_background = True
+            self._transparent_background = True
             self.palette.make_transparent(0)
         else:
-            self.transparent_background = False
+            self._transparent_background = False
             self.palette[0] = background_color
         self.palette[1] = color
 
@@ -176,7 +176,7 @@ class Label(displayio.Group):
     @property
     def background_color(self):
         """Color of the background as an RGB hex number."""
-        if not self.transparent_background:
+        if not self._transparent_background:
             return self.palette[0]
         return None
 
@@ -185,11 +185,11 @@ class Label(displayio.Group):
         if new_color or new_color == 0x000000:
             self.palette[0] = new_color
             self.palette.make_opaque(0)
-            self.transparent_background = False
+            self._transparent_background = False
         else:
             self.palette[0] = 0
             self.palette.make_transparent(0)
-            self.transparent_background = True
+            self._transparent_background = True
 
     @property
     def text(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -71,12 +71,14 @@ class Label(displayio.Group):
         self.y = y
 
         self.palette = displayio.Palette(2)
-        if not background_color:
-            self._transparent_background = True
-            self.palette.make_transparent(0)
-        else:
+        if background_color or background_color == 0x000000:
+            self.palette[0] = new_color
+            self.palette.make_opaque(0)
             self._transparent_background = False
-            self.palette[0] = background_color
+        else:
+            self.palette[0] = 0
+            self.palette.make_transparent(0)
+            self._transparent_background = True
         self.palette[1] = color
 
         bounds = self.font.get_bounding_box()

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -172,6 +172,19 @@ class Label(displayio.Group):
         self.palette[1] = new_color
 
     @property
+    def background_color(self):
+        """Color of the background as an RGB hex number."""
+        return self.palette[0]
+
+    @background_color.setter
+    def background_color(self, new_color):
+        if new_color:
+            self.palette[0] = new_color
+            self.palette.make_opaque(0)
+        else:
+            self.palette.make_transparent(0)
+
+    @property
     def text(self):
         """Text to display."""
         return self._text

--- a/examples/display_text_background_color.py
+++ b/examples/display_text_background_color.py
@@ -7,7 +7,7 @@ from adafruit_display_text import label
 
 
 text = " Color Background Hello world"
-text_area = label.Label(terminalio.FONT, text=text, color=0x0000FF, backgroud_color=0xFFAA00)
+text_area = label.Label(terminalio.FONT, text=text, color=0x0000FF, background_color=0xFFAA00)
 text_area.x = 10
 text_area.y = 10
 board.DISPLAY.show(text_area)

--- a/examples/display_text_background_color.py
+++ b/examples/display_text_background_color.py
@@ -1,15 +1,25 @@
 """
 This examples shows the use color and background_color
 """
+import time
 import board
 import terminalio
 from adafruit_display_text import label
-
 
 text = " Color Background Hello world"
 text_area = label.Label(terminalio.FONT, text=text, color=0x0000FF, background_color=0xFFAA00)
 text_area.x = 10
 text_area.y = 10
+
+print("background color is {:06x}".format(text_area.background_color))
+
 board.DISPLAY.show(text_area)
+
+time.sleep(2)
+text_area.background_color = 0xFF0000
+print("background color is {:06x}".format(text_area.background_color))
+time.sleep(2)
+text_area.background_color = None
+print("background color is {}".format(text_area.background_color))
 while True:
     pass

--- a/examples/display_text_background_color.py
+++ b/examples/display_text_background_color.py
@@ -1,0 +1,15 @@
+"""
+This examples shows the use color and background_color
+"""
+import board
+import terminalio
+from adafruit_display_text import label
+
+
+text = " Color Background Hello world"
+text_area = label.Label(terminalio.FONT, text=text, color=0x0000FF, backgroud_color=0xFFAA00)
+text_area.x = 10
+text_area.y = 10
+board.DISPLAY.show(text_area)
+while True:
+    pass


### PR DESCRIPTION
This change allows you to set background_color of the label in the constructor or with a property. Setting background_color to false, or excluding it entirely will result in same current behavior which is transparent background. This is referenced in issue #33. 