### PR TITLE
Create getter/setter for font

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -235,13 +235,14 @@ class Label(displayio.Group):
         return self._font
 
     @font.setter
-    def font(self, newFont):
-        old_text = self._text
-        self._text = ""
-        self._font = newFont
+    def font(self, new_font):
+        old_text=self._text
+        self._text=''
+        self._font=new_font
         bounds = self._font.get_bounding_box()
-        self.height = bounds[1]
+        self.height = bounds[1] 
         self._update_text(str(old_text))
+
 
     @property
     def anchor_point(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -231,7 +231,7 @@ class Label(displayio.Group):
 
     @property
     def font(self):
-        """Font to use for text."""
+        """Font to use for text display."""
         return self._font
 
     @font.setter

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -32,7 +32,6 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 """
 
-print('loading label.py Yay!')
 
 import displayio
 
@@ -110,7 +109,6 @@ class Label(displayio.Group):
             )
             / 2
         )
-        # print("y offset from baseline", y_offset)
         left = right = top = bottom = 0
         for character in new_text:
             if character == "\n":
@@ -163,7 +161,7 @@ class Label(displayio.Group):
 
             x += glyph.shift_x
 
-            # TODO skip this for control sequences or non-printables.
+            # TODO skip this for control sequences or non-qables.
             i += 1
             old_c += 1
             # skip all non-prinables in the old string

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -231,9 +231,7 @@ class Label(displayio.Group):
 
     @property
     def font(self):
-        """
-        Font to use for text display.
-        """
+        """Font to use for text display."""
         return self._font
 
     @font.setter

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -231,7 +231,9 @@ class Label(displayio.Group):
 
     @property
     def font(self):
-        """Font to use for text display."""
+        """
+        Font to use for text display.
+        """
         return self._font
 
     @font.setter

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -232,6 +232,7 @@ class Label(displayio.Group):
 
     @property
     def font(self):
+        """Font to use for text."""
         return self._font
 
     @font.setter

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -43,6 +43,7 @@ class Label(displayio.Group):
        properties will be the left edge of the bounding box, and in the center of a M
        glyph (if its one line), or the (number of lines * linespacing + M)/2. That is,
        it will try to have it be center-left as close as possible.
+       
        :param Font font: A font class that has ``get_bounding_box`` and ``get_glyph``.
          Must include a capital M for measuring character size.
        :param str text: Text to display

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -236,13 +236,12 @@ class Label(displayio.Group):
 
     @font.setter
     def font(self, new_font):
-        old_text=self._text
-        self._text=''
-        self._font=new_font
+        old_text = self._text
+        self._text = ""
+        self._font = new_font
         bounds = self._font.get_bounding_box()
-        self.height = bounds[1] 
+        self.height = bounds[1]
         self._update_text(str(old_text))
-
 
     @property
     def anchor_point(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -32,7 +32,6 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 """
 
-
 import displayio
 
 __version__ = "0.0.0-auto.0"

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -100,8 +100,6 @@ class Label(displayio.Group):
         y = 0
         i = 0
         old_c = 0
-        bounds = self._font.get_bounding_box() # moved here ***
-        self.height = bounds[1] # moved here ***
         y_offset = int(
             (
                 self._font.get_glyph(ord("M")).height
@@ -238,9 +236,11 @@ class Label(displayio.Group):
 
     @font.setter
     def font(self, newFont):
-        old_text=self._text
-        self._text=''
-        self._font=newFont
+        old_text = self._text
+        self._text = ""
+        self._font = newFont
+        bounds = self._font.get_bounding_box()
+        self.height = bounds[1]
         self._update_text(str(old_text))
 
     @property

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -22,14 +22,21 @@
 """
 `adafruit_display_text.label`
 ====================================================
+
 Displays text labels using CircuitPython's displayio.
+
 * Author(s): Scott Shawcroft
+
 Implementation Notes
 --------------------
+
 **Hardware:**
+
 **Software and Dependencies:**
+
 * Adafruit CircuitPython firmware for the supported boards:
   https://github.com/adafruit/circuitpython/releases
+
 """
 
 import displayio

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -22,22 +22,17 @@
 """
 `adafruit_display_text.label`
 ====================================================
-
 Displays text labels using CircuitPython's displayio.
-
 * Author(s): Scott Shawcroft
-
 Implementation Notes
 --------------------
-
 **Hardware:**
-
 **Software and Dependencies:**
-
 * Adafruit CircuitPython firmware for the supported boards:
   https://github.com/adafruit/circuitpython/releases
-
 """
+
+print('loading label.py Yay!')
 
 import displayio
 
@@ -50,7 +45,6 @@ class Label(displayio.Group):
        properties will be the left edge of the bounding box, and in the center of a M
        glyph (if its one line), or the (number of lines * linespacing + M)/2. That is,
        it will try to have it be center-left as close as possible.
-
        :param Font font: A font class that has ``get_bounding_box`` and ``get_glyph``.
          Must include a capital M for measuring character size.
        :param str text: Text to display
@@ -77,7 +71,7 @@ class Label(displayio.Group):
             max_glyphs = len(text)
         super().__init__(max_size=max_glyphs, **kwargs)
         self.width = max_glyphs
-        self.font = font
+        self._font = font
         self._text = None
         self._anchor_point = (0, 0)
         self.x = x
@@ -94,7 +88,7 @@ class Label(displayio.Group):
             self._transparent_background = True
         self.palette[1] = color
 
-        bounds = self.font.get_bounding_box()
+        bounds = self._font.get_bounding_box()
         self.height = bounds[1]
         self._line_spacing = line_spacing
         self._boundingbox = None
@@ -107,9 +101,11 @@ class Label(displayio.Group):
         y = 0
         i = 0
         old_c = 0
+        bounds = self._font.get_bounding_box() # moved here ***
+        self.height = bounds[1] # moved here ***
         y_offset = int(
             (
-                self.font.get_glyph(ord("M")).height
+                self._font.get_glyph(ord("M")).height
                 - new_text.count("\n") * self.height * self.line_spacing
             )
             / 2
@@ -121,7 +117,7 @@ class Label(displayio.Group):
                 y += int(self.height * self._line_spacing)
                 x = 0
                 continue
-            glyph = self.font.get_glyph(ord(character))
+            glyph = self._font.get_glyph(ord(character))
             if not glyph:
                 continue
             right = max(right, x + glyph.width)
@@ -176,7 +172,7 @@ class Label(displayio.Group):
                 and old_c < len(self._text)
                 and (
                     self._text[old_c] == "\n"
-                    or not self.font.get_glyph(ord(self._text[old_c]))
+                    or not self._font.get_glyph(ord(self._text[old_c]))
                 )
             ):
                 old_c += 1
@@ -237,6 +233,17 @@ class Label(displayio.Group):
     @text.setter
     def text(self, new_text):
         self._update_text(str(new_text))
+
+    @property
+    def font(self):
+        return self._font
+
+    @font.setter
+    def font(self, newFont):
+        old_text=self._text
+        self._text=''
+        self._font=newFont
+        self._update_text(str(old_text))
 
     @property
     def anchor_point(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -43,13 +43,16 @@ class Label(displayio.Group):
        properties will be the left edge of the bounding box, and in the center of a M
        glyph (if its one line), or the (number of lines * linespacing + M)/2. That is,
        it will try to have it be center-left as close as possible.
-       
+
        :param Font font: A font class that has ``get_bounding_box`` and ``get_glyph``.
          Must include a capital M for measuring character size.
        :param str text: Text to display
        :param int max_glyphs: The largest quantity of glyphs we will display
        :param int color: Color of all text in RGB hex
        :param double line_spacing: Line spacing of text to display"""
+
+    # pylint: disable=too-many-instance-attributes
+    # This has a lot of getters/setters, maybe it needs cleanup.
 
     def __init__(
         self,


### PR DESCRIPTION
The label class had the "font" exposed as a variable without an explicit getter/setter.  This lead to unexpected results, such as only part of the label getting redrawn with the new font, and some of the old font remaining.  That is, some of the characters would be using the "old" font and only the changed characters would use the "new" font.  When changing the font with label.font=newFont, and calling for a text update, the drawing is only be updated for characters that were changed.  

In this pull request, I am adding an explicit definition of getter and setter for the font.  This added getter/setter causes the complete text string to be re-rendered from scratch.  By setting `self._text = ''`, then the call to `self._update_text(old_text)` will execute a full redraw of the text with the updated font.