### PR TITLE
Fix anchor_position getter/setter, anchor_point setter and display_text_anchored_position example

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -235,13 +235,14 @@ class Label(displayio.Group):
         return self._font
 
     @font.setter
-    def font(self, newFont):
-        old_text = self._text
-        self._text = ""
-        self._font = newFont
+    def font(self, new_font):
+        old_text=self._text
+        self._text=''
+        self._font=new_font
         bounds = self._font.get_bounding_box()
-        self.height = bounds[1]
+        self.height = bounds[1] 
         self._update_text(str(old_text))
+
 
     @property
     def anchor_point(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -259,11 +259,11 @@ class Label(displayio.Group):
         """Position relative to the anchor_point. Tuple containing x,y
            pixel coordinates."""
         return (
-            self.x - self._boundingbox[2] * self._anchor_point[0],
-            self.y - self._boundingbox[3] * self._anchor_point[1],
+            int(self.x + self._boundingbox[0] + self._anchor_point[0] * self._boundingbox[2]),
+            int(self.y + self._boundingbox[1] + self._anchor_point[1] * self._boundingbox[3]),
         )
 
     @anchored_position.setter
     def anchored_position(self, new_position):
-        self.x = int(new_position[0] - (self._boundingbox[2] * self._anchor_point[0]))
-        self.y = int(new_position[1] - (self._boundingbox[3] * self._anchor_point[1]))
+        self.x = int(new_position[0] - self._boundingbox[0] - self._anchor_point[0] * self._boundingbox[2])
+        self.y = int(new_position[1] - self._boundingbox[1] - self._anchor_point[1] * self._boundingbox[3])

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -231,7 +231,7 @@ class Label(displayio.Group):
 
     @property
     def font(self):
-        """Font to use for text."""
+        """Font to use for text display."""
         return self._font
 
     @font.setter

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -32,7 +32,6 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 """
 
-print('loading label.py Yay!')
 
 import displayio
 
@@ -110,7 +109,6 @@ class Label(displayio.Group):
             )
             / 2
         )
-        # print("y offset from baseline", y_offset)
         left = right = top = bottom = 0
         for character in new_text:
             if character == "\n":
@@ -163,7 +161,7 @@ class Label(displayio.Group):
 
             x += glyph.shift_x
 
-            # TODO skip this for control sequences or non-printables.
+            # TODO skip this for control sequences or non-qables.
             i += 1
             old_c += 1
             # skip all non-prinables in the old string

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -61,7 +61,6 @@ class Label(displayio.Group):
     # pylint: disable=too-many-instance-attributes
     # This has a lot of getters/setters, maybe it needs cleanup.
 
-
     def __init__(
         self,
         font,

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -231,9 +231,7 @@ class Label(displayio.Group):
 
     @property
     def font(self):
-        """
-        Font to use for text display.
-        """
+        """Font to use for text display."""
         return self._font
 
     @font.setter

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -169,10 +169,10 @@ class Label(displayio.Group):
 
             x += glyph.shift_x
 
-            # TODO skip this for control sequences or non-qables.
+            # TODO skip this for control sequences or non-printables.
             i += 1
             old_c += 1
-            # skip all non-prinables in the old string
+            # skip all non-printables in the old string
             while (
                 self._text
                 and old_c < len(self._text)

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -58,6 +58,10 @@ class Label(displayio.Group):
        :param int color: Color of all text in RGB hex
        :param double line_spacing: Line spacing of text to display"""
 
+    # pylint: disable=too-many-instance-attributes
+    # This has a lot of getters/setters, maybe it needs cleanup.
+
+
     def __init__(
         self,
         font,

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -231,7 +231,9 @@ class Label(displayio.Group):
 
     @property
     def font(self):
-        """Font to use for text display."""
+        """
+        Font to use for text display.
+        """
         return self._font
 
     @font.setter

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -232,6 +232,7 @@ class Label(displayio.Group):
 
     @property
     def font(self):
+        """Font to use for text."""
         return self._font
 
     @font.setter

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -43,6 +43,7 @@ class Label(displayio.Group):
        properties will be the left edge of the bounding box, and in the center of a M
        glyph (if its one line), or the (number of lines * linespacing + M)/2. That is,
        it will try to have it be center-left as close as possible.
+       
        :param Font font: A font class that has ``get_bounding_box`` and ``get_glyph``.
          Must include a capital M for measuring character size.
        :param str text: Text to display

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -227,7 +227,9 @@ class Label(displayio.Group):
 
     @text.setter
     def text(self, new_text):
+        current_anchored_position = self.anchored_position
         self._update_text(str(new_text))
+        self.anchored_position = current_anchored_position
 
     @property
     def font(self):
@@ -237,11 +239,13 @@ class Label(displayio.Group):
     @font.setter
     def font(self, new_font):
         old_text = self._text
+        current_anchored_position = self.anchored_position
         self._text = ""
         self._font = new_font
         bounds = self._font.get_bounding_box()
         self.height = bounds[1]
         self._update_text(str(old_text))
+        self.anchored_position = current_anchored_position
 
     @property
     def anchor_point(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -259,11 +259,27 @@ class Label(displayio.Group):
         """Position relative to the anchor_point. Tuple containing x,y
            pixel coordinates."""
         return (
-            int(self.x + self._boundingbox[0] + self._anchor_point[0] * self._boundingbox[2]),
-            int(self.y + self._boundingbox[1] + self._anchor_point[1] * self._boundingbox[3]),
+            int(
+                self.x
+                + self._boundingbox[0]
+                + self._anchor_point[0] * self._boundingbox[2]
+            ),
+            int(
+                self.y
+                + self._boundingbox[1]
+                + self._anchor_point[1] * self._boundingbox[3]
+            ),
         )
 
     @anchored_position.setter
     def anchored_position(self, new_position):
-        self.x = int(new_position[0] - self._boundingbox[0] - self._anchor_point[0] * self._boundingbox[2])
-        self.y = int(new_position[1] - self._boundingbox[1] - self._anchor_point[1] * self._boundingbox[3])
+        self.x = int(
+            new_position[0]
+            - self._boundingbox[0]
+            - self._anchor_point[0] * self._boundingbox[2]
+        )
+        self.y = int(
+            new_position[1]
+            - self._boundingbox[1]
+            - self._anchor_point[1] * self._boundingbox[3]
+        )

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -236,13 +236,12 @@ class Label(displayio.Group):
 
     @font.setter
     def font(self, new_font):
-        old_text=self._text
-        self._text=''
-        self._font=new_font
+        old_text = self._text
+        self._text = ""
+        self._font = new_font
         bounds = self._font.get_bounding_box()
-        self.height = bounds[1] 
+        self.height = bounds[1]
         self._update_text(str(old_text))
-
 
     @property
     def anchor_point(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -22,14 +22,20 @@
 """
 `adafruit_display_text.label`
 ====================================================
+
 Displays text labels using CircuitPython's displayio.
+
 * Author(s): Scott Shawcroft
+
 Implementation Notes
 --------------------
+
 **Hardware:**
 **Software and Dependencies:**
+
 * Adafruit CircuitPython firmware for the supported boards:
   https://github.com/adafruit/circuitpython/releases
+
 """
 
 import displayio
@@ -43,16 +49,13 @@ class Label(displayio.Group):
        properties will be the left edge of the bounding box, and in the center of a M
        glyph (if its one line), or the (number of lines * linespacing + M)/2. That is,
        it will try to have it be center-left as close as possible.
-       
+
        :param Font font: A font class that has ``get_bounding_box`` and ``get_glyph``.
          Must include a capital M for measuring character size.
        :param str text: Text to display
        :param int max_glyphs: The largest quantity of glyphs we will display
        :param int color: Color of all text in RGB hex
        :param double line_spacing: Line spacing of text to display"""
-
-    # pylint: disable=too-many-instance-attributes
-    # This has several getters and setters, maybe needs to be cleaned up.
 
     def __init__(
         self,

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -32,7 +32,6 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 """
 
-
 import displayio
 
 __version__ = "0.0.0-auto.0"

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -100,8 +100,6 @@ class Label(displayio.Group):
         y = 0
         i = 0
         old_c = 0
-        bounds = self._font.get_bounding_box() # moved here ***
-        self.height = bounds[1] # moved here ***
         y_offset = int(
             (
                 self._font.get_glyph(ord("M")).height
@@ -238,9 +236,11 @@ class Label(displayio.Group):
 
     @font.setter
     def font(self, newFont):
-        old_text=self._text
-        self._text=''
-        self._font=newFont
+        old_text = self._text
+        self._text = ""
+        self._font = newFont
+        bounds = self._font.get_bounding_box()
+        self.height = bounds[1]
         self._update_text(str(old_text))
 
     @property

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -50,6 +50,9 @@ class Label(displayio.Group):
        :param int color: Color of all text in RGB hex
        :param double line_spacing: Line spacing of text to display"""
 
+    # pylint: disable=too-many-instance-attributes
+    # This has several getters and setters, maybe needs to be cleaned up.
+
     def __init__(
         self,
         font,

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -252,7 +252,9 @@ class Label(displayio.Group):
 
     @anchor_point.setter
     def anchor_point(self, new_anchor_point):
+        current_anchored_position = self.anchored_position
         self._anchor_point = new_anchor_point
+        self.anchored_position = current_anchored_position
 
     @property
     def anchored_position(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -31,6 +31,7 @@ Implementation Notes
 --------------------
 
 **Hardware:**
+
 **Software and Dependencies:**
 
 * Adafruit CircuitPython firmware for the supported boards:

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -22,22 +22,17 @@
 """
 `adafruit_display_text.label`
 ====================================================
-
 Displays text labels using CircuitPython's displayio.
-
 * Author(s): Scott Shawcroft
-
 Implementation Notes
 --------------------
-
 **Hardware:**
-
 **Software and Dependencies:**
-
 * Adafruit CircuitPython firmware for the supported boards:
   https://github.com/adafruit/circuitpython/releases
-
 """
+
+print('loading label.py Yay!')
 
 import displayio
 
@@ -50,7 +45,6 @@ class Label(displayio.Group):
        properties will be the left edge of the bounding box, and in the center of a M
        glyph (if its one line), or the (number of lines * linespacing + M)/2. That is,
        it will try to have it be center-left as close as possible.
-
        :param Font font: A font class that has ``get_bounding_box`` and ``get_glyph``.
          Must include a capital M for measuring character size.
        :param str text: Text to display
@@ -77,7 +71,7 @@ class Label(displayio.Group):
             max_glyphs = len(text)
         super().__init__(max_size=max_glyphs, **kwargs)
         self.width = max_glyphs
-        self.font = font
+        self._font = font
         self._text = None
         self._anchor_point = (0, 0)
         self.x = x
@@ -94,7 +88,7 @@ class Label(displayio.Group):
             self._transparent_background = True
         self.palette[1] = color
 
-        bounds = self.font.get_bounding_box()
+        bounds = self._font.get_bounding_box()
         self.height = bounds[1]
         self._line_spacing = line_spacing
         self._boundingbox = None
@@ -107,9 +101,11 @@ class Label(displayio.Group):
         y = 0
         i = 0
         old_c = 0
+        bounds = self._font.get_bounding_box() # moved here ***
+        self.height = bounds[1] # moved here ***
         y_offset = int(
             (
-                self.font.get_glyph(ord("M")).height
+                self._font.get_glyph(ord("M")).height
                 - new_text.count("\n") * self.height * self.line_spacing
             )
             / 2
@@ -121,7 +117,7 @@ class Label(displayio.Group):
                 y += int(self.height * self._line_spacing)
                 x = 0
                 continue
-            glyph = self.font.get_glyph(ord(character))
+            glyph = self._font.get_glyph(ord(character))
             if not glyph:
                 continue
             right = max(right, x + glyph.width)
@@ -176,7 +172,7 @@ class Label(displayio.Group):
                 and old_c < len(self._text)
                 and (
                     self._text[old_c] == "\n"
-                    or not self.font.get_glyph(ord(self._text[old_c]))
+                    or not self._font.get_glyph(ord(self._text[old_c]))
                 )
             ):
                 old_c += 1
@@ -237,6 +233,17 @@ class Label(displayio.Group):
     @text.setter
     def text(self, new_text):
         self._update_text(str(new_text))
+
+    @property
+    def font(self):
+        return self._font
+
+    @font.setter
+    def font(self, newFont):
+        old_text=self._text
+        self._text=''
+        self._font=newFont
+        self._update_text(str(old_text))
 
     @property
     def anchor_point(self):

--- a/examples/display_text_anchored_position.py
+++ b/examples/display_text_anchored_position.py
@@ -12,19 +12,19 @@ TEXT = "Hello"
 
 text_area_top_left = label.Label(terminalio.FONT, text=TEXT)
 text_area_top_left.anchor_point = (0.0, 0.0)
-text_area_top_left.anchored_position = (10, 10)
+text_area_top_left.anchored_position = (0, 0)
 
 text_area_top_middle = label.Label(terminalio.FONT, text=TEXT)
 text_area_top_middle.anchor_point = (0.5, 0.0)
-text_area_top_middle.anchored_position = (DISPLAY_WIDTH / 2, 10)
+text_area_top_middle.anchored_position = (DISPLAY_WIDTH / 2, 0)
 
 text_area_top_right = label.Label(terminalio.FONT, text=TEXT)
 text_area_top_right.anchor_point = (1.0, 0.0)
-text_area_top_right.anchored_position = (DISPLAY_WIDTH - 10, 10)
+text_area_top_right.anchored_position = (DISPLAY_WIDTH, 0)
 
 text_area_middle_left = label.Label(terminalio.FONT, text=TEXT)
 text_area_middle_left.anchor_point = (0.0, 0.5)
-text_area_middle_left.anchored_position = (10, DISPLAY_HEIGHT / 2)
+text_area_middle_left.anchored_position = (0, DISPLAY_HEIGHT / 2)
 
 text_area_middle_middle = label.Label(terminalio.FONT, text=TEXT)
 text_area_middle_middle.anchor_point = (0.5, 0.5)
@@ -32,11 +32,11 @@ text_area_middle_middle.anchored_position = (DISPLAY_WIDTH / 2, DISPLAY_HEIGHT /
 
 text_area_middle_right = label.Label(terminalio.FONT, text=TEXT)
 text_area_middle_right.anchor_point = (1.0, 0.5)
-text_area_middle_right.anchored_position = (DISPLAY_WIDTH - 10, DISPLAY_HEIGHT / 2)
+text_area_middle_right.anchored_position = (DISPLAY_WIDTH, DISPLAY_HEIGHT / 2)
 
 text_area_bottom_left = label.Label(terminalio.FONT, text=TEXT)
 text_area_bottom_left.anchor_point = (0.0, 1.0)
-text_area_bottom_left.anchored_position = (10, DISPLAY_HEIGHT)
+text_area_bottom_left.anchored_position = (0, DISPLAY_HEIGHT)
 
 text_area_bottom_middle = label.Label(terminalio.FONT, text=TEXT)
 text_area_bottom_middle.anchor_point = (0.5, 1.0)
@@ -44,7 +44,7 @@ text_area_bottom_middle.anchored_position = (DISPLAY_WIDTH / 2, DISPLAY_HEIGHT)
 
 text_area_bottom_right = label.Label(terminalio.FONT, text=TEXT)
 text_area_bottom_right.anchor_point = (1.0, 1.0)
-text_area_bottom_right.anchored_position = (DISPLAY_WIDTH - 10, DISPLAY_HEIGHT)
+text_area_bottom_right.anchored_position = (DISPLAY_WIDTH, DISPLAY_HEIGHT)
 
 text_group = displayio.Group(max_size=9)
 text_group.append(text_area_top_middle)


### PR DESCRIPTION
- I found an error in the calculations for the `anchor_position` getter and setter, that incorrectly placed the x,y locations based on the specified `anchor_point` and `anchor_position`.  I updated these calculations to be correct.

- I updated the `anchor_point` setter so that the x,y positions are recalculated upon a change to anchor_point.  

- I updated the example/display_text_anchored_position.py so that the tested anchor positions are directly at the edge and corners of the display

- Updated the `font` and `text` setters such that `anchored_position` is properly updated.

Verification:
I verified on an ItsyBitsy NRF52840 running an ILI9341 display 320x240 pixels running the Adafruit display driver.

Other impacts:
This update may "break" existing projects using `label` since the positions of the labels will likely change versus with the current version.  I will understand if this change will cause more trouble than help.  Any feedback or suggestion is welcome.

Another note:
Unfortunately, I made these changes on the my local branch that also has an outstanding pull request for the font updates ([see pull request #42](https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/pull/42)).   I recommend cancelling [PR #42](https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/pull/42) and focusing on this one.

However, let me know if you would like me break this out into two separate pull requests all back to the adafruit/master branch. 