### PR TITLE
Updated bounding_box "right" value to include trailing whitespace

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -126,7 +126,7 @@ class Label(displayio.Group):
             glyph = self._font.get_glyph(ord(character))
             if not glyph:
                 continue
-            right = max(right, x + glyph.width)
+            right = max(right, x + glyph.width + glyph.shift_x)
             if y == 0:  # first line, find the Ascender height
                 top = min(top, -glyph.height + y_offset)
             bottom = max(bottom, y - glyph.dy + y_offset)


### PR DESCRIPTION
The problem:  Current label's bounding_box does not including the pixels for trailing whitespace (or any glyphs that rely on the font's "shift_x" parameter).  So, if you create a label and then use the bounding_box to set the next bit of text, then any spaces will seem like they weren't ever printed.

The fix: The "right" parameter for the bounding_box is updated to include any "glyph.shift_x", for example when a trailing whitespace is present.  This will ensure that any glyphs that used "shift_x" will be accounted-for in the right edge of the bounding_box.

Potential negative impacts:  Could mess up someone's label placement if they are already accounting for this missing space at the end.
