### PR TITLE
catch group full exception and re-raise with more descriptive message

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -238,9 +238,12 @@ class Label(displayio.Group):
 
     @text.setter
     def text(self, new_text):
-        current_anchored_position = self.anchored_position
-        self._update_text(str(new_text))
-        self.anchored_position = current_anchored_position
+        try:
+            current_anchored_position = self.anchored_position
+            self._update_text(str(new_text))
+            self.anchored_position = current_anchored_position
+        except RuntimeError:
+            raise RuntimeError("Text length exceeds max_glyphs")
 
     @property
     def font(self):


### PR DESCRIPTION
Solves #11

This will show a more helpful message when user tries to set text to a string that is too long.