### PR TITLE
Updated background color handling for label

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -319,7 +319,6 @@ class Label(displayio.Group):
         current_anchored_position = self.anchored_position
         self._text = ""
         self._font = new_font
-        # bounds = self._font.get_bounding_box()
         self.height = self._font.get_bounding_box()[1]
         self._update_text(str(old_text))
         self.anchored_position = current_anchored_position

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -125,7 +125,7 @@ class Label(displayio.Group):
 
     def _update_background_color(self, new_color):
 
-        if new_color == None:
+        if new_color is None:
             self._background_palette.make_transparent(0)
         else:
             self._background_palette.make_opaque(0)
@@ -228,13 +228,15 @@ class Label(displayio.Group):
         else:  # draw a "loose" bounding box to include any ascenders/descenders.
 
             # check a few glyphs for maximum ascender and descender height
-            # Enhancement: it would be preferred to access the font "FONT_ASCENT" and "FONT_DESCENT" in the imported BDF file
-            glyphs = "M j'"  # choose glyphs with highest ascender and lowest descender, will depend upon font used
+            # Enhancement: it would be preferred to access the font "FONT_ASCENT" and 
+            # "FONT_DESCENT" in the imported BDF file
+            glyphs = "M j'" # choose glyphs with highest ascender and lowest 
+                            # descender, will depend upon font used
             ascender_max = descender_max = 0
             for char in glyphs:
-                thisGlyph = self._font.get_glyph(ord(char))
-                ascender_max = max(ascender_max, thisGlyph.height + thisGlyph.dy)
-                descender_max = max(descender_max, -thisGlyph.dy)
+                this_glyph = self._font.get_glyph(ord(char))
+                ascender_max = max(ascender_max, this_glyph.height + this_glyph.dy)
+                descender_max = max(descender_max, -this_glyph.dy)
 
             box_width = self._boundingbox[2] + self._padding_left + self._padding_right
             x_box_offset = -self._padding_left

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -99,8 +99,8 @@ class Label(displayio.Group):
 
         self._background_color = background_color
 
-        bounds = self._font.get_bounding_box()
-        self.height = bounds[1]
+        #bounds = self._font.get_bounding_box()
+        self.height = self._font.get_bounding_box()[1]
         self._line_spacing = line_spacing
         self._boundingbox = None
 
@@ -115,7 +115,6 @@ class Label(displayio.Group):
             )
         )  # initialize with a blank tilegrid placeholder for background
 
-        self._padding = (padding_left, padding_top, padding_right, padding_bottom)
         self._padding_top = padding_top
         self._padding_bottom = padding_bottom
         self._padding_left = padding_left
@@ -148,16 +147,16 @@ class Label(displayio.Group):
                 descender_max = max(descender_max, -this_glyph.dy)
 
             box_width = (
-                self._boundingbox[2] + self._padding[0] + self._padding[3]
+                self._boundingbox[2] + self._padding_left + self._padding_right
             )  # left + right padding
-            x_box_offset = -self._padding[0]  # left padding
+            x_box_offset = -self._padding_left  
             box_height = (
                 (ascender_max + descender_max)
                 + int((lines - 1) * self.height * self._line_spacing)
-                + self._padding[1]  # top padding
-                + self._padding[2]  # bottom padding
+                + self._padding_top  
+                + self._padding_bottom
             )
-            y_box_offset = -ascender_max + y_offset - self._padding[1]  # top padding
+            y_box_offset = -ascender_max + y_offset - self._padding_top
 
         self._update_background_color(self._background_color)
         box_width = max(0, box_width)  # remove any negative values
@@ -369,8 +368,8 @@ class Label(displayio.Group):
         current_anchored_position = self.anchored_position
         self._text = ""
         self._font = new_font
-        bounds = self._font.get_bounding_box()
-        self.height = bounds[1]
+        #bounds = self._font.get_bounding_box()
+        self.height = self._font.get_bounding_box()[1]
         self._update_text(str(old_text))
         self.anchored_position = current_anchored_position
 

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -93,11 +93,6 @@ class Label(displayio.Group):
         self.y = y
 
         self.palette = displayio.Palette(2)
-        # if background_color is not None:
-        #     self.palette[0] = background_color
-        #     self.palette.make_opaque(0)
-        #     self._transparent_background = False
-        # else:
         self.palette[0] = 0
         self.palette.make_transparent(0)
         self._transparent_background = True
@@ -114,7 +109,6 @@ class Label(displayio.Group):
             background_tight  # sets padding status for text background
         )
         self._background_palette = displayio.Palette(1)
-        # self._background_present = False
         self.append(
             displayio.TileGrid(
                 displayio.Bitmap(0, 0, 1), pixel_shader=self._background_palette
@@ -139,13 +133,8 @@ class Label(displayio.Group):
         self._background_color = new_color
 
     def _update_text(self, new_text):  # pylint: disable=too-many-locals
-        # if self._background_present:
-        #    i=1
-        # else:
-        #    i=0
         x = 0
         y = 0
-        # i = 0
         i = 1
         old_c = 0
         y_offset = int(
@@ -166,12 +155,10 @@ class Label(displayio.Group):
             glyph = self._font.get_glyph(ord(character))
             if not glyph:
                 continue
-            # right = max(right, x + glyph.width + glyph.shift_x)
             right = max(
                 right, x + glyph.shift_x
             )  # studied the docs! This is the correct spacing
             if y == 0:  # first line, find the Ascender height
-                # top = min(top, -glyph.height + y_offset)
                 top = min(top, -glyph.height - glyph.dy + y_offset)
             bottom = max(bottom, y - glyph.dy + y_offset)
             position_y = y - glyph.height - glyph.dy + y_offset

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -95,7 +95,6 @@ class Label(displayio.Group):
         self.palette = displayio.Palette(2)
         self.palette[0] = 0
         self.palette.make_transparent(0)
-        self._transparent_background = True
         self.palette[1] = color
 
         self._background_color = background_color

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -228,10 +228,10 @@ class Label(displayio.Group):
         else:  # draw a "loose" bounding box to include any ascenders/descenders.
 
             # check a few glyphs for maximum ascender and descender height
-            # Enhancement: it would be preferred to access the font "FONT_ASCENT" and 
+            # Enhancement: it would be preferred to access the font "FONT_ASCENT" and
             # "FONT_DESCENT" in the imported BDF file
-            glyphs = "M j'" # choose glyphs with highest ascender and lowest 
-                            # descender, will depend upon font used
+            glyphs = "M j'"  # choose glyphs with highest ascender and lowest
+            # descender, will depend upon font used
             ascender_max = descender_max = 0
             for char in glyphs:
                 this_glyph = self._font.get_glyph(ord(char))

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -115,22 +115,24 @@ class Label(displayio.Group):
             )
         )  # initialize with a blank tilegrid placeholder for background
 
-        self._padding_top = padding_top
-        self._padding_bottom = padding_bottom
-        self._padding_left = padding_left
-        self._padding_right = padding_right
+        self._padding = (padding_left, padding_top, padding_right, padding_bottom)
+        # self._padding_top = padding_top
+        # self._padding_bottom = padding_bottom
+        # self._padding_left = padding_left
+        # self._padding_right = padding_right
 
         if text is not None:
             self._update_text(str(text))
 
     def _create_background_box(self, lines, y_offset):
 
+        left = self._boundingbox[0]
+
         if self._background_tight:  # draw a tight bounding box
             box_width = self._boundingbox[2]
             box_height = self._boundingbox[3]
             x_box_offset = 0
-            y_box_offset = self._bounding_box[1]
-            left = self._bounding_box[0]
+            y_box_offset = self._boundingbox[1]
 
         else:  # draw a "loose" bounding box to include any ascenders/descenders.
 
@@ -145,15 +147,17 @@ class Label(displayio.Group):
                 ascender_max = max(ascender_max, this_glyph.height + this_glyph.dy)
                 descender_max = max(descender_max, -this_glyph.dy)
 
-            box_width = self._boundingbox[2] + self._padding_left + self._padding_right
-            x_box_offset = -self._padding_left
+            box_width = (
+                self._boundingbox[2] + self._padding[0] + self._padding[3]
+            )  # left + right padding
+            x_box_offset = -self._padding[0]  # left padding
             box_height = (
                 (ascender_max + descender_max)
                 + int((lines - 1) * self.height * self._line_spacing)
-                + self._padding_top
-                + self._padding_bottom
+                + self._padding[1]  # top padding
+                + self._padding[2]  # bottom padding
             )
-            y_box_offset = -ascender_max + y_offset - self._padding_top
+            y_box_offset = -ascender_max + y_offset - self._padding[1]  # top padding
 
         self._update_background_color(self._background_color)
         box_width = max(0, box_width)  # remove any negative values

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -99,7 +99,7 @@ class Label(displayio.Group):
 
         self._background_color = background_color
 
-        #bounds = self._font.get_bounding_box()
+        # bounds = self._font.get_bounding_box()
         self.height = self._font.get_bounding_box()[1]
         self._line_spacing = line_spacing
         self._boundingbox = None
@@ -149,11 +149,11 @@ class Label(displayio.Group):
             box_width = (
                 self._boundingbox[2] + self._padding_left + self._padding_right
             )  # left + right padding
-            x_box_offset = -self._padding_left  
+            x_box_offset = -self._padding_left
             box_height = (
                 (ascender_max + descender_max)
                 + int((lines - 1) * self.height * self._line_spacing)
-                + self._padding_top  
+                + self._padding_top
                 + self._padding_bottom
             )
             y_box_offset = -ascender_max + y_offset - self._padding_top
@@ -368,7 +368,7 @@ class Label(displayio.Group):
         current_anchored_position = self.anchored_position
         self._text = ""
         self._font = new_font
-        #bounds = self._font.get_bounding_box()
+        # bounds = self._font.get_bounding_box()
         self.height = self._font.get_bounding_box()[1]
         self._update_text(str(old_text))
         self.anchored_position = current_anchored_position

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -116,10 +116,10 @@ class Label(displayio.Group):
         )  # initialize with a blank tilegrid placeholder for background
 
         self._padding = (padding_left, padding_top, padding_right, padding_bottom)
-        # self._padding_top = padding_top
-        # self._padding_bottom = padding_bottom
-        # self._padding_left = padding_left
-        # self._padding_right = padding_right
+        self._padding_top = padding_top
+        self._padding_bottom = padding_bottom
+        self._padding_left = padding_left
+        self._padding_right = padding_right
 
         if text is not None:
             self._update_text(str(text))

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -103,17 +103,23 @@ class Label(displayio.Group):
         self._transparent_background = True
         self.palette[1] = color
 
-        self._background_color=background_color
+        self._background_color = background_color
 
         bounds = self._font.get_bounding_box()
         self.height = bounds[1]
         self._line_spacing = line_spacing
         self._boundingbox = None
 
-        self.background_tight = background_tight # sets padding status for text background
+        self.background_tight = (
+            background_tight  # sets padding status for text background
+        )
         self._background_palette = displayio.Palette(1)
-        #self._background_present = False
-        self.append(displayio.TileGrid(displayio.Bitmap(0, 0, 1), pixel_shader=self._background_palette)) # initialize with a blank tilegrid placeholder for background
+        # self._background_present = False
+        self.append(
+            displayio.TileGrid(
+                displayio.Bitmap(0, 0, 1), pixel_shader=self._background_palette
+            )
+        )  # initialize with a blank tilegrid placeholder for background
 
         self.padding_top = padding_top
         self.padding_bottom = padding_bottom
@@ -129,19 +135,18 @@ class Label(displayio.Group):
             self._background_palette.make_transparent(0)
         else:
             self._background_palette.make_opaque(0)
-            self._background_palette[0]=new_color
-        self._background_color=new_color
-
+            self._background_palette[0] = new_color
+        self._background_color = new_color
 
     def _update_text(self, new_text):  # pylint: disable=too-many-locals
-        #if self._background_present:
+        # if self._background_present:
         #    i=1
-        #else:
+        # else:
         #    i=0
         x = 0
         y = 0
-        #i = 0
-        i=1
+        # i = 0
+        i = 1
         old_c = 0
         y_offset = int(
             (
@@ -161,11 +166,13 @@ class Label(displayio.Group):
             glyph = self._font.get_glyph(ord(character))
             if not glyph:
                 continue
-            #right = max(right, x + glyph.width + glyph.shift_x)
-            right = max(right, x + glyph.shift_x) # studied the docs! This is the correct spacing
+            # right = max(right, x + glyph.width + glyph.shift_x)
+            right = max(
+                right, x + glyph.shift_x
+            )  # studied the docs! This is the correct spacing
             if y == 0:  # first line, find the Ascender height
-                #top = min(top, -glyph.height + y_offset)
-                top = min(top, - glyph.height - glyph.dy + y_offset)
+                # top = min(top, -glyph.height + y_offset)
+                top = min(top, -glyph.height - glyph.dy + y_offset)
             bottom = max(bottom, y - glyph.dy + y_offset)
             position_y = y - glyph.height - glyph.dy + y_offset
             position_x = x + glyph.dx
@@ -225,17 +232,17 @@ class Label(displayio.Group):
         self._text = new_text
         self._boundingbox = (left, top, left + right, bottom - top)
 
-        if self.background_tight: # draw a tight bounding box
+        if self.background_tight:  # draw a tight bounding box
             box_width = self._boundingbox[2]
             box_height = self._boundingbox[3]
             x_box_offset = 0
             y_box_offset = top
 
-        else: # draw a "loose" bounding box to include any ascenders/descenders.
+        else:  # draw a "loose" bounding box to include any ascenders/descenders.
 
             # check a few glyphs for maximum ascender and descender height
             # Enhancement: it would be preferred to access the font "FONT_ASCENT" and "FONT_DESCENT" in the imported BDF file
-            glyphs = 'M j\'' # choose glyphs with highest ascender and lowest descender, will depend upon font used
+            glyphs = "M j'"  # choose glyphs with highest ascender and lowest descender, will depend upon font used
             ascender_max = descender_max = 0
             for char in glyphs:
                 thisGlyph = self._font.get_glyph(ord(char))
@@ -244,19 +251,26 @@ class Label(displayio.Group):
 
             box_width = self._boundingbox[2] + self.padding_left + self.padding_right
             x_box_offset = -self.padding_left
-            box_height = (ascender_max + descender_max) + int((lines-1) * self.height * self._line_spacing) + self.padding_top + self.padding_bottom
+            box_height = (
+                (ascender_max + descender_max)
+                + int((lines - 1) * self.height * self._line_spacing)
+                + self.padding_top
+                + self.padding_bottom
+            )
             y_box_offset = -ascender_max + y_offset - self.padding_top
 
-
         self._update_background_color(self._background_color)
-        box_width=max(0, box_width) # remove any negative values
-        box_height=max(0, box_height) # remove any negative values
+        box_width = max(0, box_width)  # remove any negative values
+        box_height = max(0, box_height)  # remove any negative values
 
         background_bitmap = displayio.Bitmap(box_width, box_height, 1)
         tile_grid = displayio.TileGrid(
-            background_bitmap, pixel_shader=self._background_palette, x=left+x_box_offset, y=y_box_offset
+            background_bitmap,
+            pixel_shader=self._background_palette,
+            x=left + x_box_offset,
+            y=y_box_offset,
         )
-        self[0]=tile_grid  # update the background bitmap in first item of the group
+        self[0] = tile_grid  # update the background bitmap in first item of the group
 
     @property
     def bounding_box(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -105,9 +105,8 @@ class Label(displayio.Group):
         self._line_spacing = line_spacing
         self._boundingbox = None
 
-        self.background_tight = (
-            background_tight  # sets padding status for text background
-        )
+        self._background_tight = background_tight  # sets padding status for text background
+        
         self._background_palette = displayio.Palette(1)
         self.append(
             displayio.TileGrid(
@@ -115,10 +114,10 @@ class Label(displayio.Group):
             )
         )  # initialize with a blank tilegrid placeholder for background
 
-        self.padding_top = padding_top
-        self.padding_bottom = padding_bottom
-        self.padding_left = padding_left
-        self.padding_right = padding_right
+        self._padding_top = padding_top
+        self._padding_bottom = padding_bottom
+        self._padding_left = padding_left
+        self._padding_right = padding_right
 
         if text is not None:
             self._update_text(str(text))
@@ -219,7 +218,7 @@ class Label(displayio.Group):
         self._text = new_text
         self._boundingbox = (left, top, left + right, bottom - top)
 
-        if self.background_tight:  # draw a tight bounding box
+        if self._background_tight:  # draw a tight bounding box
             box_width = self._boundingbox[2]
             box_height = self._boundingbox[3]
             x_box_offset = 0
@@ -236,15 +235,15 @@ class Label(displayio.Group):
                 ascender_max = max(ascender_max, thisGlyph.height + thisGlyph.dy)
                 descender_max = max(descender_max, -thisGlyph.dy)
 
-            box_width = self._boundingbox[2] + self.padding_left + self.padding_right
-            x_box_offset = -self.padding_left
+            box_width = self._boundingbox[2] + self._padding_left + self._padding_right
+            x_box_offset = -self._padding_left
             box_height = (
                 (ascender_max + descender_max)
                 + int((lines - 1) * self.height * self._line_spacing)
-                + self.padding_top
-                + self.padding_bottom
+                + self._padding_top
+                + self._padding_bottom
             )
-            y_box_offset = -ascender_max + y_offset - self.padding_top
+            y_box_offset = -ascender_max + y_offset - self._padding_top
 
         self._update_background_color(self._background_color)
         box_width = max(0, box_width)  # remove any negative values

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -104,8 +104,10 @@ class Label(displayio.Group):
         self._line_spacing = line_spacing
         self._boundingbox = None
 
-        self._background_tight = background_tight  # sets padding status for text background
-        
+        self._background_tight = (
+            background_tight  # sets padding status for text background
+        )
+
         self._background_palette = displayio.Palette(1)
         self.append(
             displayio.TileGrid(

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -123,13 +123,14 @@ class Label(displayio.Group):
         if text is not None:
             self._update_text(str(text))
 
-    def _create_background_box(self, lines, left, y_offset):
+    def _create_background_box(self, lines, y_offset):
 
         if self._background_tight:  # draw a tight bounding box
             box_width = self._boundingbox[2]
             box_height = self._boundingbox[3]
             x_box_offset = 0
-            y_box_offset = top
+            y_box_offset = self._bounding_box[1]
+            left = self._bounding_box[0]
 
         else:  # draw a "loose" bounding box to include any ascenders/descenders.
 
@@ -306,7 +307,7 @@ class Label(displayio.Group):
         # )
         # self[0] = tile_grid  # update the background bitmap in first item of the group
 
-        self[0] = self._create_background_box(lines, left, y_offset)
+        self[0] = self._create_background_box(lines, y_offset)
 
     @property
     def bounding_box(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -97,17 +97,15 @@ class Label(displayio.Group):
         self.palette.make_transparent(0)
         self.palette[1] = color
 
-        self._background_color = background_color
-
-        # bounds = self._font.get_bounding_box()
         self.height = self._font.get_bounding_box()[1]
         self._line_spacing = line_spacing
         self._boundingbox = None
 
         self._background_tight = (
-            background_tight  # sets padding status for text background
+            background_tight  # sets padding status for text background box
         )
 
+        self._background_color = background_color
         self._background_palette = displayio.Palette(1)
         self.append(
             displayio.TileGrid(
@@ -146,9 +144,7 @@ class Label(displayio.Group):
                 ascender_max = max(ascender_max, this_glyph.height + this_glyph.dy)
                 descender_max = max(descender_max, -this_glyph.dy)
 
-            box_width = (
-                self._boundingbox[2] + self._padding_left + self._padding_right
-            )  # left + right padding
+            box_width = self._boundingbox[2] + self._padding_left + self._padding_right
             x_box_offset = -self._padding_left
             box_height = (
                 (ascender_max + descender_max)
@@ -204,9 +200,7 @@ class Label(displayio.Group):
             glyph = self._font.get_glyph(ord(character))
             if not glyph:
                 continue
-            right = max(
-                right, x + glyph.shift_x
-            )  # studied the docs! This is the correct spacing
+            right = max(right, x + glyph.shift_x)
             if y == 0:  # first line, find the Ascender height
                 top = min(top, -glyph.height - glyph.dy + y_offset)
             bottom = max(bottom, y - glyph.dy + y_offset)
@@ -267,49 +261,6 @@ class Label(displayio.Group):
             self.pop()
         self._text = new_text
         self._boundingbox = (left, top, left + right, bottom - top)
-
-        # if self._background_tight:  # draw a tight bounding box
-        #     box_width = self._boundingbox[2]
-        #     box_height = self._boundingbox[3]
-        #     x_box_offset = 0
-        #     y_box_offset = top
-
-        # else:  # draw a "loose" bounding box to include any ascenders/descenders.
-
-        #     # check a few glyphs for maximum ascender and descender height
-        #     # Enhancement: it would be preferred to access the font "FONT_ASCENT" and
-        #     # "FONT_DESCENT" in the imported BDF file
-        #     glyphs = "M j'"  # choose glyphs with highest ascender and lowest
-        #     # descender, will depend upon font used
-        #     ascender_max = descender_max = 0
-        #     for char in glyphs:
-        #         this_glyph = self._font.get_glyph(ord(char))
-        #         ascender_max = max(ascender_max, this_glyph.height + this_glyph.dy)
-        #         descender_max = max(descender_max, -this_glyph.dy)
-
-        #     box_width = self._boundingbox[2] + self._padding_left + self._padding_right
-        #     x_box_offset = -self._padding_left
-        #     box_height = (
-        #         (ascender_max + descender_max)
-        #         + int((lines - 1) * self.height * self._line_spacing)
-        #         + self._padding_top
-        #         + self._padding_bottom
-        #     )
-        #     y_box_offset = -ascender_max + y_offset - self._padding_top
-
-        # self._update_background_color(self._background_color)
-        # box_width = max(0, box_width)  # remove any negative values
-        # box_height = max(0, box_height)  # remove any negative values
-
-        # background_bitmap = displayio.Bitmap(box_width, box_height, 1)
-        # tile_grid = displayio.TileGrid(
-        #     background_bitmap,
-        #     pixel_shader=self._background_palette,
-        #     x=left + x_box_offset,
-        #     y=y_box_offset,
-        # )
-        # self[0] = tile_grid  # update the background bitmap in first item of the group
-
         self[0] = self._create_background_box(lines, y_offset)
 
     @property

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -77,7 +77,7 @@ class Label(displayio.Group):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
         if not max_glyphs:
-            max_glyphs = len(text)
+            max_glyphs = len(text) + 1  # add one for the background bitmap tileGrid
         super().__init__(max_size=max_glyphs, **kwargs)
         self.width = max_glyphs
         self._font = font
@@ -187,6 +187,18 @@ class Label(displayio.Group):
             self.pop()
         self._text = new_text
         self._boundingbox = (left, top, left + right, bottom - top)
+
+        background_bitmap = displayio.Bitmap(
+            self._boundingbox[2], self._boundingbox[3], 1
+        )
+
+        tile_grid = displayio.TileGrid(
+            background_bitmap, pixel_shader=self.palette, x=left, y=top
+        )
+
+        self.insert(
+            0, tile_grid
+        )  # add background bitmaps to the bottom layer of the group
 
     @property
     def bounding_box(self):

--- a/examples/display_text_background_color_padding.py
+++ b/examples/display_text_background_color_padding.py
@@ -4,14 +4,11 @@ This examples shows the use color and background_color
 import board
 import displayio
 import time
-import terminalio
-import fontio
-import sys
-import busio
 
 # from adafruit_st7789 import ST7789
 from adafruit_ili9341 import ILI9341
 from adafruit_display_text import label
+from adafruit_bitmap_font import bitmap_font
 
 #  Setup the SPI display
 
@@ -27,7 +24,6 @@ tft_reset = board.D11
 
 while not spi.try_lock():
     spi.configure(baudrate=32000000)
-    pass
 spi.unlock()
 
 display_bus = displayio.FourWire(
@@ -56,9 +52,7 @@ display = ILI9341(
 
 display.show(None)
 
-# font=terminalio.FONT
-
-from adafruit_bitmap_font import bitmap_font
+# font=terminalio.FONT # this is the Builtin fixed dimension font
 
 font = bitmap_font.load_font("fonts/BitstreamVeraSans-Roman-24.bdf")
 
@@ -105,9 +99,9 @@ print("background color is {}".format(text_area[0].background_color))
 
 while True:
     time.sleep(2)
-    text_area[
-        0
-    ].text = "text"  # change some text in an existing text box (must fit within existing # of characters)
+    text_area[0].text = "text"  # change some text in an existing text box
+    # Note: changed text must fit within existing number of characters
+    # when the Label was created
 
     for area in text_area:
         area.background_color = 0xFF0000

--- a/examples/display_text_background_color_padding.py
+++ b/examples/display_text_background_color_padding.py
@@ -1,9 +1,10 @@
 """
 This examples shows the use color and background_color
 """
+import time
 import board
 import displayio
-import time
+
 
 # from adafruit_st7789 import ST7789
 from adafruit_ili9341 import ILI9341

--- a/examples/display_text_background_color_padding.py
+++ b/examples/display_text_background_color_padding.py
@@ -1,0 +1,119 @@
+"""
+This examples shows the use color and background_color
+"""
+import board
+import displayio
+import time
+import terminalio
+import fontio
+import sys
+import busio
+#from adafruit_st7789 import ST7789
+from adafruit_ili9341 import ILI9341
+from adafruit_display_text import label
+
+#  Setup the SPI display
+
+print('Starting the display...') # goes to serial only
+displayio.release_displays()
+
+
+spi = board.SPI()
+tft_cs = board.D9 # arbitrary, pin not used
+tft_dc = board.D10
+tft_backlight = board.D12
+tft_reset=board.D11
+
+while not spi.try_lock():
+    spi.configure(baudrate=32000000)
+    pass
+spi.unlock()
+
+display_bus = displayio.FourWire(
+    spi,
+    command=tft_dc,
+    chip_select=tft_cs,
+    reset=tft_reset,
+    baudrate=32000000,
+    polarity=1,
+    phase=1,
+)
+
+print('spi.frequency: {}'.format(spi.frequency))
+
+DISPLAY_WIDTH=320
+DISPLAY_HEIGHT=240
+
+#display = ST7789(display_bus, width=240, height=240, rotation=0, rowstart=80, colstart=0)
+display = ILI9341(display_bus, width=DISPLAY_WIDTH, height=DISPLAY_HEIGHT, rotation=180, auto_refresh=True)
+
+display.show(None)
+
+#font=terminalio.FONT
+
+from adafruit_bitmap_font import bitmap_font
+font= bitmap_font.load_font('fonts/BitstreamVeraSans-Roman-24.bdf')
+
+
+text =[]
+text.append('none') # no ascenders or descenders
+text.append('pop quops') # only descenders
+text.append('MONSTERs are tall') # only ascenders
+text.append('MONSTERs ate pop quops') # both ascenders and descenders
+text.append('MONSTER quops\nnewline quops') # with newline
+
+display.auto_refresh=True
+myGroup=displayio.Group(max_size=6)
+display.show(myGroup)
+
+text_area=[]
+myPadding=4
+
+for i, thisText in enumerate(text):
+    text_area.append ( label.Label(
+        font, text=thisText, color=0xFFFFFF, background_color=None,
+        background_tight=False,
+        padding_top=myPadding,
+        padding_bottom=myPadding,
+        padding_left=myPadding,
+        padding_right=myPadding,
+    ) )
+    
+    this_x=10
+    this_y=10 + i*40
+    text_area[i].x = 10 
+    text_area[i].y = 3 + i*50
+    text_area[i].anchor_point = (0,0) 
+    text_area[i].anchored_position = (this_x, this_y)
+    myGroup.append(text_area[i])
+
+print("background color is {}".format(text_area[0].background_color))
+
+
+while True:
+    time.sleep(2)
+    text_area[0].text='text' # change some text in an existing text box (must fit within existing # of characters)
+    
+
+    for area in text_area:
+        area.background_color = 0xFF0000
+    print("background color is {:06x}".format(text_area[0].background_color))
+    time.sleep(2)
+    for area in text_area:
+        area.background_color = 0x000088
+    print("background color is {:06x}".format(text_area[0].background_color))
+    time.sleep(2)
+    for area in text_area:
+        area.background_color = 0x00FF00
+    print("background color is {:06x}".format(text_area[0].background_color))
+    time.sleep(2)
+    for area in text_area:
+        area.background_color = 0xFF0000
+    print("background color is {:06x}".format(text_area[0].background_color))
+    time.sleep(2)
+    for area in text_area:
+        area.background_color = None
+    print("background color is {}".format(text_area[0].background_color))
+
+
+

--- a/examples/display_text_background_color_padding.py
+++ b/examples/display_text_background_color_padding.py
@@ -8,21 +8,22 @@ import terminalio
 import fontio
 import sys
 import busio
-#from adafruit_st7789 import ST7789
+
+# from adafruit_st7789 import ST7789
 from adafruit_ili9341 import ILI9341
 from adafruit_display_text import label
 
 #  Setup the SPI display
 
-print('Starting the display...') # goes to serial only
+print("Starting the display...")  # goes to serial only
 displayio.release_displays()
 
 
 spi = board.SPI()
-tft_cs = board.D9 # arbitrary, pin not used
+tft_cs = board.D9  # arbitrary, pin not used
 tft_dc = board.D10
 tft_backlight = board.D12
-tft_reset=board.D11
+tft_reset = board.D11
 
 while not spi.try_lock():
     spi.configure(baudrate=32000000)
@@ -39,51 +40,63 @@ display_bus = displayio.FourWire(
     phase=1,
 )
 
-print('spi.frequency: {}'.format(spi.frequency))
+print("spi.frequency: {}".format(spi.frequency))
 
-DISPLAY_WIDTH=320
-DISPLAY_HEIGHT=240
+DISPLAY_WIDTH = 320
+DISPLAY_HEIGHT = 240
 
-#display = ST7789(display_bus, width=240, height=240, rotation=0, rowstart=80, colstart=0)
-display = ILI9341(display_bus, width=DISPLAY_WIDTH, height=DISPLAY_HEIGHT, rotation=180, auto_refresh=True)
+# display = ST7789(display_bus, width=240, height=240, rotation=0, rowstart=80, colstart=0)
+display = ILI9341(
+    display_bus,
+    width=DISPLAY_WIDTH,
+    height=DISPLAY_HEIGHT,
+    rotation=180,
+    auto_refresh=True,
+)
 
 display.show(None)
 
-#font=terminalio.FONT
+# font=terminalio.FONT
 
 from adafruit_bitmap_font import bitmap_font
-font= bitmap_font.load_font('fonts/BitstreamVeraSans-Roman-24.bdf')
+
+font = bitmap_font.load_font("fonts/BitstreamVeraSans-Roman-24.bdf")
 
 
-text =[]
-text.append('none') # no ascenders or descenders
-text.append('pop quops') # only descenders
-text.append('MONSTERs are tall') # only ascenders
-text.append('MONSTERs ate pop quops') # both ascenders and descenders
-text.append('MONSTER quops\nnewline quops') # with newline
+text = []
+text.append("none")  # no ascenders or descenders
+text.append("pop quops")  # only descenders
+text.append("MONSTERs are tall")  # only ascenders
+text.append("MONSTERs ate pop quops")  # both ascenders and descenders
+text.append("MONSTER quops\nnewline quops")  # with newline
 
-display.auto_refresh=True
-myGroup=displayio.Group(max_size=6)
+display.auto_refresh = True
+myGroup = displayio.Group(max_size=6)
 display.show(myGroup)
 
-text_area=[]
-myPadding=4
+text_area = []
+myPadding = 4
 
 for i, thisText in enumerate(text):
-    text_area.append ( label.Label(
-        font, text=thisText, color=0xFFFFFF, background_color=None,
-        background_tight=False,
-        padding_top=myPadding,
-        padding_bottom=myPadding,
-        padding_left=myPadding,
-        padding_right=myPadding,
-    ) )
-    
-    this_x=10
-    this_y=10 + i*40
-    text_area[i].x = 10 
-    text_area[i].y = 3 + i*50
-    text_area[i].anchor_point = (0,0) 
+    text_area.append(
+        label.Label(
+            font,
+            text=thisText,
+            color=0xFFFFFF,
+            background_color=None,
+            background_tight=False,
+            padding_top=myPadding,
+            padding_bottom=myPadding,
+            padding_left=myPadding,
+            padding_right=myPadding,
+        )
+    )
+
+    this_x = 10
+    this_y = 10 + i * 40
+    text_area[i].x = 10
+    text_area[i].y = 3 + i * 50
+    text_area[i].anchor_point = (0, 0)
     text_area[i].anchored_position = (this_x, this_y)
     myGroup.append(text_area[i])
 
@@ -92,8 +105,9 @@ print("background color is {}".format(text_area[0].background_color))
 
 while True:
     time.sleep(2)
-    text_area[0].text='text' # change some text in an existing text box (must fit within existing # of characters)
-    
+    text_area[
+        0
+    ].text = "text"  # change some text in an existing text box (must fit within existing # of characters)
 
     for area in text_area:
         area.background_color = 0xFF0000
@@ -114,6 +128,3 @@ while True:
     for area in text_area:
         area.background_color = None
     print("background color is {}".format(text_area[0].background_color))
-
-
-


### PR DESCRIPTION
When using imported BDF font files with proportional typefaces, the current version of label with applied background color only covers the glyphs but not the whitespace.  Also, spaces provide some errant dots.  See image:
![IMG_0653](https://user-images.githubusercontent.com/33587466/83716281-14a2b700-a5f5-11ea-9033-da363e01eb90.JPG)

This PR creates an additional colored bitmap tileGrid as the bottom layer below the text that is the size of the bounding box around the glyph text.  The following three images show examples of the proposed PR with differing text.

Note: The bounding box is a simple minimum bounding box to fit the whole set of glyphs.  This means that text with no ascenders and descenders (see second image below `mere a or o`) will have a smaller bounding box than other lines with taller letters.

Possible enhancements:
* Draw a bounding box the same height for all characters, to cover the space of ascenders and descenders.  This would be important when writing multiple lines of text, since it may be obvious to the viewer that the height of background text boxes differs based on the text in them.
* To avoid excess background fill regions (see last image) print each line separately so the bounding boxes will not extend past the right edge of the text.  

![IMG_0659](https://user-images.githubusercontent.com/33587466/83716383-5df30680-a5f5-11ea-8fc6-daed9b5da84e.JPG)
![IMG_0660](https://user-images.githubusercontent.com/33587466/83716385-5fbcca00-a5f5-11ea-8b0b-a3b234010dff.JPG)
![IMG_0664](https://user-images.githubusercontent.com/33587466/83716402-6cd9b900-a5f5-11ea-91ac-491bee671bb0.JPG)


