### PR TITLE
Add NoneType check for glyph height

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -141,8 +141,9 @@ class Label(displayio.Group):
             ascender_max = descender_max = 0
             for char in glyphs:
                 this_glyph = self._font.get_glyph(ord(char))
-                ascender_max = max(ascender_max, this_glyph.height + this_glyph.dy)
-                descender_max = max(descender_max, -this_glyph.dy)
+                if this_glyph:
+                    ascender_max = max(ascender_max, this_glyph.height + this_glyph.dy)
+                    descender_max = max(descender_max, -this_glyph.dy)
 
             box_width = self._boundingbox[2] + self._padding_left + self._padding_right
             x_box_offset = -self._padding_left


### PR DESCRIPTION
For #50. Adds a simple check to make sure the glyph is not a NoneType.
```python
Adafruit CircuitPython 5.3.0 on 2020-04-29; Adafruit Circuit Playground Bluefruit with nRF52840
>>> from adafruit_bitmap_font import bitmap_font
>>> from adafruit_display_text import label
>>> font = bitmap_font.load_font("/monoMMM_5_90.bdf")
>>> my_label = label.Label(font, text="hello", color=0xFFFFFF)
>>> 
```