### PR TITLE
fix max_glyphs count when text wasn't passed in constructor

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -82,8 +82,9 @@ class Label(displayio.Group):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
         if not max_glyphs:
-            max_glyphs = len(text) + 1  # add one for the background bitmap tileGrid
-        super().__init__(max_size=max_glyphs, **kwargs)
+            max_glyphs = len(text)
+        # add one to max_size for the background bitmap tileGrid
+        super().__init__(max_size=max_glyphs + 1, **kwargs)
 
         self.width = max_glyphs
         self._font = font


### PR DESCRIPTION
Issue was originally raised here: https://forums.adafruit.com/viewtopic.php?f=60&t=166798

This change will always include `+1` to the value it passes for `max_size` to the super class Group. The extra one accounts for the background tilegrid which was introduced recently to fix background color for custom fonts. This way it does not matter whether the user passes `text` or `max_glyphs` in the constructor, the behavior is the same both ways.

Crash with current version and fix with new version tested with this:
```python
import board
import terminalio
from adafruit_display_text import label


text = "Hello"
text_area = label.Label(terminalio.FONT, max_glyphs=5)
text_area.x = 10
text_area.y = 10
text_area.text = text
board.DISPLAY.show(text_area)
while True:
    pass
```