### PR TITLE
fix for anchored_position to work correctly with scaled label

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -79,6 +79,10 @@ class Label(displayio.Group):
         padding_right=0,
         **kwargs
     ):
+        if "scale" in kwargs.keys():
+            self._scale = kwargs["scale"]
+        else:
+            self._scale = 1
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
         if not max_glyphs:
@@ -361,13 +365,15 @@ class Label(displayio.Group):
 
     @anchored_position.setter
     def anchored_position(self, new_position):
-        self.x = int(
+        new_x = int(
             new_position[0]
-            - self._boundingbox[0]
-            - self._anchor_point[0] * self._boundingbox[2]
+            - self._anchor_point[0] * (self._boundingbox[2] * self._scale)
         )
-        self.y = int(
+        new_y = self.y = int(
             new_position[1]
-            - self._boundingbox[1]
-            - self._anchor_point[1] * self._boundingbox[3]
+            - self._anchor_point[1] * (self._boundingbox[3] * self._scale)
+            + (self._boundingbox[3] * self._scale) / 2
         )
+        self._boundingbox = (new_x, new_y, self._boundingbox[2], self._boundingbox[3])
+        self.x = new_x
+        self.y = new_y


### PR DESCRIPTION
This attempts to solve #55 

It turned out there were a few issues with the existing handling of anchored position leading to it not working correctly with scale. 

 - As noted on a comment in #55 the scale parameter in `__init__()` was actually belonging to the super class Group which does allow it to visually scale the text properly. But Label itself was not remembering or doing anything with the scale.

 - The math in the `anchored_position` setter was taking into account the current (x, y) position of the label when determining the new one. But I don't think this is needed, the only things needed to determine the new position should be: the new desired coordinates, the anchor_point, and the width and height.

These changes resolve those issues by keeping the scale in `self._scale` and accounting for it when setting the `anchored_position`. As well as removing the unneeded referencing of the previous x,y position during calculations.

Changes were tested with this code: 
```python
import terminalio, displayio, board
from adafruit_display_text import label
text_area = label.Label(
    terminalio.FONT,
    text="Scale!", scale=5, color=0xc0c0c0, 
    background_color=0x0000FF
)
text_area.anchor_point = (0,0)
board.DISPLAY.show(text_area)
text_area.anchored_position = (0,0)  ### expectation is text will be on screen at top left
while True:
    pass
```
After these changes the label in this script is now positioned properly in the top left corner of the screen. 

I also tested with the [display_text_anchored_position.py](https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/blob/master/examples/display_text_anchored_position.py) example and it seems to still be working properly after these changes.