### PR TITLE
Bitmap zero - Creates 1-pixel bitmap during initialization of tilegrid for background of label

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -351,9 +351,10 @@ class Label(displayio.Group):
         """Position relative to the anchor_point. Tuple containing x,y
            pixel coordinates."""
         return (
-            int(self.x + self._anchor_point[0] * self._boundingbox[2]),
-            int(self.y + self._anchor_point[1] * self._boundingbox[3]),
-        )
+            int(self.x + self._anchor_point[0] * self._boundingbox[2] * self._scale ),
+            int(self.y + self._anchor_point[1] * self._boundingbox[3] * self._scale 
+                    - (self._boundingbox[3] * self._scale)/2 )
+                )
 
     @anchored_position.setter
     def anchored_position(self, new_position):
@@ -364,6 +365,7 @@ class Label(displayio.Group):
         new_y = self.y = int(
             new_position[1]
             - self._anchor_point[1] * (self._boundingbox[3] * self._scale)
+            + (self._boundingbox[3] * self._scale)/2
         )
         self._boundingbox = (new_x, new_y, self._boundingbox[2], self._boundingbox[3])
         self.x = new_x

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -235,13 +235,14 @@ class Label(displayio.Group):
         return self._font
 
     @font.setter
-    def font(self, newFont):
-        old_text = self._text
-        self._text = ""
-        self._font = newFont
+    def font(self, new_font):
+        old_text=self._text
+        self._text=''
+        self._font=new_font
         bounds = self._font.get_bounding_box()
-        self.height = bounds[1]
+        self.height = bounds[1] 
         self._update_text(str(old_text))
+
 
     @property
     def anchor_point(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -353,12 +353,10 @@ class Label(displayio.Group):
         return (
             int(
                 self.x
-                + self._boundingbox[0]
                 + self._anchor_point[0] * self._boundingbox[2]
             ),
             int(
                 self.y
-                + self._boundingbox[1]
                 + self._anchor_point[1] * self._boundingbox[3]
             ),
         )
@@ -372,7 +370,6 @@ class Label(displayio.Group):
         new_y = self.y = int(
             new_position[1]
             - self._anchor_point[1] * (self._boundingbox[3] * self._scale)
-            + (self._boundingbox[3] * self._scale) / 2
         )
         self._boundingbox = (new_x, new_y, self._boundingbox[2], self._boundingbox[3])
         self.x = new_x

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -231,7 +231,7 @@ class Label(displayio.Group):
 
     @property
     def font(self):
-        """Font to use for text."""
+        """Font to use for text display."""
         return self._font
 
     @font.setter

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -164,17 +164,14 @@ class Label(displayio.Group):
         box_width = max(0, box_width)  # remove any negative values
         box_height = max(0, box_height)  # remove any negative values
 
-        if box_width > 0 and box_height > 0:
-            background_bitmap = displayio.Bitmap(box_width, box_height, 1)
-            tile_grid = displayio.TileGrid(
-                background_bitmap,
-                pixel_shader=self._background_palette,
-                x=left + x_box_offset,
-                y=y_box_offset,
-            )
-            return tile_grid
-        else:
-            return None
+        background_bitmap = displayio.Bitmap(box_width, box_height, 1)
+        tile_grid = displayio.TileGrid(
+            background_bitmap,
+            pixel_shader=self._background_palette,
+            x=left + x_box_offset,
+            y=y_box_offset,
+        )
+        return tile_grid
 
     def _update_background_color(self, new_color):
 

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -231,9 +231,7 @@ class Label(displayio.Group):
 
     @property
     def font(self):
-        """
-        Font to use for text display.
-        """
+        """Font to use for text display."""
         return self._font
 
     @font.setter

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -114,7 +114,7 @@ class Label(displayio.Group):
         self._background_palette = displayio.Palette(1)
         self.append(
             displayio.TileGrid(
-                displayio.Bitmap(0, 0, 1), pixel_shader=self._background_palette
+                displayio.Bitmap(1, 1, 1), pixel_shader=self._background_palette
             )
         )  # initialize with a blank tilegrid placeholder for background
 

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -231,7 +231,9 @@ class Label(displayio.Group):
 
     @property
     def font(self):
-        """Font to use for text display."""
+        """
+        Font to use for text display.
+        """
         return self._font
 
     @font.setter

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -232,6 +232,7 @@ class Label(displayio.Group):
 
     @property
     def font(self):
+        """Font to use for text."""
         return self._font
 
     @font.setter

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -43,6 +43,7 @@ class Label(displayio.Group):
        properties will be the left edge of the bounding box, and in the center of a M
        glyph (if its one line), or the (number of lines * linespacing + M)/2. That is,
        it will try to have it be center-left as close as possible.
+       
        :param Font font: A font class that has ``get_bounding_box`` and ``get_glyph``.
          Must include a capital M for measuring character size.
        :param str text: Text to display

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -351,14 +351,8 @@ class Label(displayio.Group):
         """Position relative to the anchor_point. Tuple containing x,y
            pixel coordinates."""
         return (
-            int(
-                self.x
-                + self._anchor_point[0] * self._boundingbox[2]
-            ),
-            int(
-                self.y
-                + self._anchor_point[1] * self._boundingbox[3]
-            ),
+            int(self.x + self._anchor_point[0] * self._boundingbox[2]),
+            int(self.y + self._anchor_point[1] * self._boundingbox[3]),
         )
 
     @anchored_position.setter

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -236,13 +236,12 @@ class Label(displayio.Group):
 
     @font.setter
     def font(self, new_font):
-        old_text=self._text
-        self._text=''
-        self._font=new_font
+        old_text = self._text
+        self._text = ""
+        self._font = new_font
         bounds = self._font.get_bounding_box()
-        self.height = bounds[1] 
+        self.height = bounds[1]
         self._update_text(str(old_text))
-
 
     @property
     def anchor_point(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -32,7 +32,6 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 """
 
-
 import displayio
 
 __version__ = "0.0.0-auto.0"

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -100,8 +100,6 @@ class Label(displayio.Group):
         y = 0
         i = 0
         old_c = 0
-        bounds = self._font.get_bounding_box() # moved here ***
-        self.height = bounds[1] # moved here ***
         y_offset = int(
             (
                 self._font.get_glyph(ord("M")).height
@@ -238,9 +236,11 @@ class Label(displayio.Group):
 
     @font.setter
     def font(self, newFont):
-        old_text=self._text
-        self._text=''
-        self._font=newFont
+        old_text = self._text
+        self._text = ""
+        self._font = newFont
+        bounds = self._font.get_bounding_box()
+        self.height = bounds[1]
         self._update_text(str(old_text))
 
     @property

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -22,14 +22,21 @@
 """
 `adafruit_display_text.label`
 ====================================================
+
 Displays text labels using CircuitPython's displayio.
+
 * Author(s): Scott Shawcroft
+
 Implementation Notes
 --------------------
+
 **Hardware:**
+
 **Software and Dependencies:**
+
 * Adafruit CircuitPython firmware for the supported boards:
   https://github.com/adafruit/circuitpython/releases
+
 """
 
 import displayio

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -272,7 +272,6 @@ class Label(displayio.Group):
         self._boundingbox = (left, top, left + right, bottom - top)
         self[0] = self._create_background_box(lines, y_offset)
 
-
     @property
     def bounding_box(self):
         """An (x, y, w, h) tuple that completely covers all glyphs. The
@@ -316,11 +315,8 @@ class Label(displayio.Group):
     def text(self, new_text):
         try:
             current_anchored_position = self.anchored_position
-            print('start anchored_position: {}'.format(self.anchored_position))
-            print('self.y: {}, self._scale: {}'.format(self.y, self._scale))
             self._update_text(str(new_text))
             self.anchored_position = current_anchored_position
-            print('end anchored_position: {}'.format(self.anchored_position))
         except RuntimeError:
             raise RuntimeError("Text length exceeds max_glyphs")
 
@@ -357,10 +353,13 @@ class Label(displayio.Group):
         """Position relative to the anchor_point. Tuple containing x,y
            pixel coordinates."""
         return (
-            int(self.x + (self._anchor_point[0] * self._boundingbox[2] * self._scale) ),
-            int(self.y + (self._anchor_point[1] * self._boundingbox[3] * self._scale) 
-                    - round( (self._boundingbox[3] * self._scale)/2.0 ))
-                )              
+            int(self.x + (self._anchor_point[0] * self._boundingbox[2] * self._scale)),
+            int(
+                self.y
+                + (self._anchor_point[1] * self._boundingbox[3] * self._scale)
+                - round((self._boundingbox[3] * self._scale) / 2.0)
+            ),
+        )
 
     @anchored_position.setter
     def anchored_position(self, new_position):
@@ -370,12 +369,9 @@ class Label(displayio.Group):
         )
         new_y = int(
             new_position[1]
-            - ( self._anchor_point[1] * self._boundingbox[3] * self._scale)
-            + round( (self._boundingbox[3] * self._scale)/2.0 )
+            - (self._anchor_point[1] * self._boundingbox[3] * self._scale)
+            + round((self._boundingbox[3] * self._scale) / 2.0)
         )
-
-        print('new_y: {}, new_position[1]: {}, self._anchor_point[1]: {}, self._boundingbox[3]: {}'.format(new_y, new_position[1], self._anchor_point[1], self._boundingbox[3]))
-
         self._boundingbox = (new_x, new_y, self._boundingbox[2], self._boundingbox[3])
         self.x = new_x
         self.y = new_y

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -43,13 +43,16 @@ class Label(displayio.Group):
        properties will be the left edge of the bounding box, and in the center of a M
        glyph (if its one line), or the (number of lines * linespacing + M)/2. That is,
        it will try to have it be center-left as close as possible.
-       
+
        :param Font font: A font class that has ``get_bounding_box`` and ``get_glyph``.
          Must include a capital M for measuring character size.
        :param str text: Text to display
        :param int max_glyphs: The largest quantity of glyphs we will display
        :param int color: Color of all text in RGB hex
        :param double line_spacing: Line spacing of text to display"""
+
+    # pylint: disable=too-many-instance-attributes
+    # This has a lot of getters/setters, maybe it needs cleanup.
 
     def __init__(
         self,


### PR DESCRIPTION
Resolving zero-sized bitmap identified in issue #58.

To include a colored background for text, a single bitmap (in a TileGrid) is used as the first element of the display group.  The first item is this background bitmap, and the remaining items are TileGrid elements, each with one character of text.

To overcome the zero-sized bitmap, I updated the initial instancing of the TileGrid to include a non-zero sized bitmap (single pixel).  

Note: This initial instance in the group is a place holder that is later updated to the correct size after all the text is created.  An alternate approach could be to create all the text TileGrids, then create the bitmap and insert it into the first position of the group.  Also, do we need to check for a zero-sized `box_width` and `box_height` before setting the bitmap background?


Also, I updated the `anchored_position` getter and setter to prevent movement of the label when the text was updated (#60).  I repaired an off-by-one error due to a difference in `int()` that truncates the decimals and changed it to `round()`.
