### PR TITLE
fix anchored position getter and setter

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -351,15 +351,11 @@ class Label(displayio.Group):
         """Position relative to the anchor_point. Tuple containing x,y
            pixel coordinates."""
         return (
-            int(
-                self.x
-                + self._boundingbox[0]
-                + self._anchor_point[0] * self._boundingbox[2]
-            ),
+            int(self.x + (self._anchor_point[0] * self._boundingbox[2] * self._scale)),
             int(
                 self.y
-                + self._boundingbox[1]
-                + self._anchor_point[1] * self._boundingbox[3]
+                + (self._anchor_point[1] * self._boundingbox[3] * self._scale)
+                - round((self._boundingbox[3] * self._scale) / 2.0)
             ),
         )
 
@@ -369,11 +365,10 @@ class Label(displayio.Group):
             new_position[0]
             - self._anchor_point[0] * (self._boundingbox[2] * self._scale)
         )
-        new_y = self.y = int(
+        new_y = int(
             new_position[1]
-            - self._anchor_point[1] * (self._boundingbox[3] * self._scale)
-            + (self._boundingbox[3] * self._scale) / 2
+            - (self._anchor_point[1] * self._boundingbox[3] * self._scale)
+            + round((self._boundingbox[3] * self._scale) / 2.0)
         )
-        self._boundingbox = (new_x, new_y, self._boundingbox[2], self._boundingbox[3])
         self.x = new_x
         self.y = new_y


### PR DESCRIPTION
I believe these changes should fix issues related to the label getting moved to unexpected places when using `anchored_position` getter and setters. 