### PR TITLE
Check for zero width/height glyphs

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -261,7 +261,7 @@ class Label(displayio.Group):
                 not self._text
                 or old_c >= len(self._text)
                 or character != self._text[old_c]
-            ):
+            ) and (glyph.width > 0 and glyph.height > 0):
                 try:
                     # pylint: disable=unexpected-keyword-arg
                     face = displayio.TileGrid(


### PR DESCRIPTION
This update ensures that glyph.width and glyph.height are > 0.  For some BDF font files, the spaces can be generated as zero-width.  This change will ensure that no tileGrid is created for zero-width glyphs.