### PR TITLE
corrected index replacement of tileGrid, and deletion of unused tileGrids

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -232,6 +232,7 @@ class Label(displayio.Group):
             i = 1
         else:
             i = 0
+        tilegrid_count = i
         y_offset = int(
             (
                 self._font.get_glyph(ord("M")).height
@@ -277,14 +278,16 @@ class Label(displayio.Group):
                         x=position_x,
                         y=position_y,
                     )
-                if i < len(self):
-                    self[i] = face
+                if tilegrid_count < len(self):
+                    self[tilegrid_count] = face
                 else:
                     self.append(face)
+                tilegrid_count += 1
             x += glyph.shift_x
             i += 1
         # Remove the rest
-        while len(self) > i:
+
+        while len(self) > tilegrid_count:  # i:
             self.pop()
         self._text = new_text
         self._boundingbox = (left, top, left + right, bottom - top)


### PR DESCRIPTION

This is resolves leftover characters as identifed in: https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/issues/67.

The issue was related to the skipping of the tileGrid elements when a blank glyph is present.  I created a different tilegrid_count index to resolve this.