### PR TITLE
dont use bitmap and tilegrid background for builtin fonts

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -310,7 +310,8 @@ class Label(displayio.Group):
         self._boundingbox = (left, top, left + right, bottom - top)
 
         if not isinstance(self.font, BuiltinFont):
-            self._update_background_color(self._background_color)
+            if self._background_color:
+                self._update_background_color(self._background_color)
 
     @property
     def bounding_box(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -103,8 +103,9 @@ class Label(displayio.Group):
             self.palette[0] = 0
             self.palette.make_transparent(0)
         else:
-            self.palette[0] = background_color
-            self.palette.make_opaque(0)
+            if isinstance(self.font, BuiltinFont):
+                self.palette[0] = background_color
+                self.palette.make_opaque(0)
         self.palette[1] = color
 
         self.height = self._font.get_bounding_box()[1]

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -175,6 +175,7 @@ class Label(displayio.Group):
         return tile_grid
 
     def _update_background_color(self, new_color):
+        # pylint: disable=too-many-branches
         if isinstance(self.font, BuiltinFont):
             if new_color is not None:
                 self.palette[0] = new_color
@@ -207,10 +208,12 @@ class Label(displayio.Group):
                 if (
                     (len(self._text) > 0)
                     and (
-                        self._boundingbox[2] + self._padding_left + self._padding_right > 0
+                        self._boundingbox[2] + self._padding_left + self._padding_right
+                        > 0
                     )
                     and (
-                        self._boundingbox[3] + self._padding_top + self._padding_bottom > 0
+                        self._boundingbox[3] + self._padding_top + self._padding_bottom
+                        > 0
                     )
                 ):
                     if len(self) > 0:
@@ -224,10 +227,12 @@ class Label(displayio.Group):
                 if (
                     (len(self._text) > 0)
                     and (
-                        self._boundingbox[2] + self._padding_left + self._padding_right > 0
+                        self._boundingbox[2] + self._padding_left + self._padding_right
+                        > 0
                     )
                     and (
-                        self._boundingbox[3] + self._padding_top + self._padding_bottom > 0
+                        self._boundingbox[3] + self._padding_top + self._padding_bottom
+                        > 0
                     )
                 ):
                     self[0] = self._create_background_box(lines, y_offset)

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -99,13 +99,12 @@ class Label(displayio.Group):
         self.y = y
 
         self.palette = displayio.Palette(2)
-        if not background_color:
+        if isinstance(self.font, BuiltinFont) and (background_color is not None):
+            self.palette[0] = background_color
+            self.palette.make_opaque(0)
+        else:
             self.palette[0] = 0
             self.palette.make_transparent(0)
-        else:
-            if isinstance(self.font, BuiltinFont):
-                self.palette[0] = background_color
-                self.palette.make_opaque(0)
         self.palette[1] = color
 
         self.height = self._font.get_bounding_box()[1]
@@ -368,6 +367,21 @@ class Label(displayio.Group):
 
     @font.setter
     def font(self, new_font):
+        if (
+            isinstance(new_font, BuiltinFont)
+            or not isinstance(new_font, BuiltinFont)
+            and self.background_color is None
+        ):
+            if self._added_background_tilegrid:
+                self.pop(0)
+                self._added_background_tilegrid = False
+        if isinstance(new_font, BuiltinFont) and (self.background_color is not None):
+            self.palette[0] = self.background_color
+            self.palette.make_opaque(0)
+        else:
+            self.palette[0] = 0
+            self.palette.make_transparent(0)
+
         old_text = self._text
         current_anchored_position = self.anchored_position
         self._text = ""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["displayio"]
+autodoc_mock_imports = ["displayio", "fontio"]
 
 
 intersphinx_mapping = {


### PR DESCRIPTION
This change should revert back to the old background behavior without bitmap and tilegrid when `terminalio.FONT` (or any BuiltinFont) is in use. 

I tested briefly with Kevin's circle animation script form here: https://github.com/kevinjwalters/circuitpython-examples/blob/master/clue/clue-label-test.py but modified to use only a single label and library instance. 

It seems like this does bring back the previous animation performance. 

I still intend to do some more thorough testing over the next few days. This almost certainly still needs black, pylint and perhaps sphinx checks. 

@kmatch98 and/or @kevinjwalters if you have a moment please check out this version and let me know what you think. 