### PR TITLE
Added anchor_point and anchor_position options as parameters

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -58,7 +58,7 @@ class Label(displayio.Group):
        :param int color: Color of all text in RGB hex
        :param double line_spacing: Line spacing of text to display"""
 
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-instance-attributes, too-many-locals
     # This has a lot of getters/setters, maybe it needs cleanup.
 
     def __init__(


### PR DESCRIPTION
This is to resolve https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/issues/44

This updates the _init_ parameters to allow the `anchor_point` and `anchor_position` to be set when the label is instanced. 

Note: Somehow the diff shows many more changes than expected. Let me know if I need to update my fork to clarify these changes. But to do so I will need to educate myself on exactly how to do the appropriate git incantations. 

