### PR TITLE
Updated label.py to correct position of initial blank text

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -397,15 +397,14 @@ class Label(displayio.Group):
     def anchored_position(self, new_position):
         if (self._anchor_point is None) or (new_position is None):
             return  # Note: anchor_point must be set before setting anchored_position
-        else:
-            new_x = int(
-                new_position[0]
-                - self._anchor_point[0] * (self._boundingbox[2] * self._scale)
-            )
-            new_y = int(
-                new_position[1]
-                - (self._anchor_point[1] * self._boundingbox[3] * self._scale)
-                + round((self._boundingbox[3] * self._scale) / 2.0)
-            )
-            self.x = new_x
-            self.y = new_y
+        new_x = int(
+            new_position[0]
+            - self._anchor_point[0] * (self._boundingbox[2] * self._scale)
+        )
+        new_y = int(
+            new_position[1]
+            - (self._anchor_point[1] * self._boundingbox[3] * self._scale)
+            + round((self._boundingbox[3] * self._scale) / 2.0)
+        )
+        self.x = new_x
+        self.y = new_y

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -396,7 +396,7 @@ class Label(displayio.Group):
     @anchored_position.setter
     def anchored_position(self, new_position):
         if (self._anchor_point is None) or (new_position is None):
-            pass  # Note: anchor_point must be set before setting anchored_position
+            return  # Note: anchor_point must be set before setting anchored_position
         else:
             new_x = int(
                 new_position[0]

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -395,8 +395,8 @@ class Label(displayio.Group):
 
     @anchored_position.setter
     def anchored_position(self, new_position):
-        if (self._anchor_point is None) or (new_position is None): 
-            pass # Note: anchor_point must be set before setting anchored_position
+        if (self._anchor_point is None) or (new_position is None):
+            pass  # Note: anchor_point must be set before setting anchored_position
         else:
             new_x = int(
                 new_position[0]

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -95,10 +95,7 @@ class Label(displayio.Group):
         self.width = max_glyphs
         self._font = font
         self._text = None
-        if anchor_point is None:
-            self._anchor_point = (0, 0)
-        else:
-            self._anchor_point = anchor_point
+        self._anchor_point = anchor_point
         self.x = x
         self.y = y
 
@@ -126,7 +123,7 @@ class Label(displayio.Group):
 
         if text is not None:
             self._update_text(str(text))
-        if anchored_position is not None:
+        if (anchored_position is not None) and (anchor_point is not None):
             self.anchored_position = anchored_position
 
     def _create_background_box(self, lines, y_offset):
@@ -374,14 +371,19 @@ class Label(displayio.Group):
 
     @anchor_point.setter
     def anchor_point(self, new_anchor_point):
-        current_anchored_position = self.anchored_position
-        self._anchor_point = new_anchor_point
-        self.anchored_position = current_anchored_position
+        if self._anchor_point is not None:
+            current_anchored_position = self.anchored_position
+            self._anchor_point = new_anchor_point
+            self.anchored_position = current_anchored_position
+        else:
+            self._anchor_point = new_anchor_point
 
     @property
     def anchored_position(self):
         """Position relative to the anchor_point. Tuple containing x,y
            pixel coordinates."""
+        if self._anchor_point is None:
+            return None
         return (
             int(self.x + (self._anchor_point[0] * self._boundingbox[2] * self._scale)),
             int(
@@ -393,14 +395,17 @@ class Label(displayio.Group):
 
     @anchored_position.setter
     def anchored_position(self, new_position):
-        new_x = int(
-            new_position[0]
-            - self._anchor_point[0] * (self._boundingbox[2] * self._scale)
-        )
-        new_y = int(
-            new_position[1]
-            - (self._anchor_point[1] * self._boundingbox[3] * self._scale)
-            + round((self._boundingbox[3] * self._scale) / 2.0)
-        )
-        self.x = new_x
-        self.y = new_y
+        if (self._anchor_point is None) or (new_position is None): 
+            pass # Note: anchor_point must be set before setting anchored_position
+        else:
+            new_x = int(
+                new_position[0]
+                - self._anchor_point[0] * (self._boundingbox[2] * self._scale)
+            )
+            new_y = int(
+                new_position[1]
+                - (self._anchor_point[1] * self._boundingbox[3] * self._scale)
+                + round((self._boundingbox[3] * self._scale) / 2.0)
+            )
+            self.x = new_x
+            self.y = new_y


### PR DESCRIPTION
This is to resolve issue https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/issues/80

Some background on label positioning:
There are two ways to specify a label's position, either by `x`,`y` or by `anchor_point` and `anchored_position`.
These two methods could be inconsistent, so I coded this so that setting `anchored_position` actually updates just the x,y locations.  That way we don't have inconsistencies betwee the two.  And the `anchored_position` getter just calculates the value based on the stored `x,y` value.  
However, that means that the positioning of the label will depend upon the order of setting the position.  For example, if you set `x,y` directly, then it will go to that position until you set `anchored_position` to another value.  

In order to keep the `anchored_position` consistent, the `text` setter first gets the current `anchored_position`, then updates the text (in case the size changes) and then resets the `anchored_position` (which sets the appropriate x,y values).

To solve this issue #80, I updated `anchor_point` to allow a value of None.  That way, if the `anchor_point` is None, then the `anchored_position` is also invalid.  That will ensure that the `x,y` values are not changed when the `anchor_point` is not set and then the text is changed.  I hope this is solution is generic enough to resolve most issues like this.
