### PR TITLE
Fix anchored position rounding

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -385,7 +385,7 @@ class Label(displayio.Group):
         if self._anchor_point is None:
             return None
         return (
-            int(self.x + (self._anchor_point[0] * self._boundingbox[2] * self._scale)),
+            int(self.x + round(self._anchor_point[0] * self._boundingbox[2] * self._scale)),
             int(
                 self.y
                 + (self._anchor_point[1] * self._boundingbox[3] * self._scale)
@@ -399,7 +399,7 @@ class Label(displayio.Group):
             return  # Note: anchor_point must be set before setting anchored_position
         new_x = int(
             new_position[0]
-            - self._anchor_point[0] * (self._boundingbox[2] * self._scale)
+            - round(self._anchor_point[0] * (self._boundingbox[2] * self._scale))
         )
         new_y = int(
             new_position[1]

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -385,7 +385,10 @@ class Label(displayio.Group):
         if self._anchor_point is None:
             return None
         return (
-            int(self.x + round(self._anchor_point[0] * self._boundingbox[2] * self._scale)),
+            int(
+                self.x
+                + round(self._anchor_point[0] * self._boundingbox[2] * self._scale)
+            ),
             int(
                 self.y
                 + (self._anchor_point[1] * self._boundingbox[3] * self._scale)

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -390,9 +390,11 @@ class Label(displayio.Group):
                 + round(self._anchor_point[0] * self._boundingbox[2] * self._scale)
             ),
             int(
-                self.y
-                + (self._anchor_point[1] * self._boundingbox[3] * self._scale)
-                - round((self._boundingbox[3] * self._scale) / 2.0)
+                round(
+                    self.y
+                    + (self._anchor_point[1] * self._boundingbox[3] * self._scale)
+                    - ((self._boundingbox[3] * self._scale) / 2.0)
+                )
             ),
         )
 
@@ -405,9 +407,11 @@ class Label(displayio.Group):
             - round(self._anchor_point[0] * (self._boundingbox[2] * self._scale))
         )
         new_y = int(
-            new_position[1]
-            - (self._anchor_point[1] * self._boundingbox[3] * self._scale)
-            + round((self._boundingbox[3] * self._scale) / 2.0)
+            round(
+                new_position[1]
+                - (self._anchor_point[1] * self._boundingbox[3] * self._scale)
+                + ((self._boundingbox[3] * self._scale) / 2.0)
+            )
         )
         self.x = new_x
         self.y = new_y


### PR DESCRIPTION
This resolves #82. The sample script in that issue and several other variations of it that I tested now result in the label remaining in the same position over time. 

