### PR TITLE
Include `load_glyphs` of full text string prior to character-processing loop in `_update_text`

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -237,6 +237,7 @@ class Label(displayio.Group):
         else:
             i = 0
         tilegrid_count = i
+        self._font.load_glyphs(new_text+"M")
         y_offset = int(
             (
                 self._font.get_glyph(ord("M")).height

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -237,7 +237,7 @@ class Label(displayio.Group):
         else:
             i = 0
         tilegrid_count = i
-        self._font.load_glyphs(new_text+"M")
+        self._font.load_glyphs(new_text + "M")
         y_offset = int(
             (
                 self._font.get_glyph(ord("M")).height


### PR DESCRIPTION
This change improves performance when font glyphs have not been loaded.  See issue: https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/issues/84

On a brief test of plotting the following line of text with Helvetica-Bold-16.bdf, the time to create the label reduced from 9.0 seconds to 0.5625 seconds:
```
my_string = "Welcome to using displayio on CircuitPython!"
```
There was no significant difference in processing time when glyphs had already been loaded.


**Note:** This update will also help with bitmap_label.py
