### PR TITLE
gracefully recover if load_glpyhs does not exist on font we are using

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -237,7 +237,13 @@ class Label(displayio.Group):
         else:
             i = 0
         tilegrid_count = i
-        self._font.load_glyphs(new_text + "M")
+
+        try:
+            self._font.load_glyphs(new_text + "M")
+        except AttributeError:
+            # ignore if font does not have load_glyphs
+            pass
+
         y_offset = int(
             (
                 self._font.get_glyph(ord("M")).height


### PR DESCRIPTION
This resolves #87.

Instead of checking if the font was `terminalio.FONT` I opted for `try/except` and ignoring the AttributeError that results from `load_glyphs` not existing. This lets us avoid having to `import terminalio` and does still solve the crash. 