### PR TITLE
`bitmap_label`: Make text, line_spacing and scale mutable

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -88,7 +88,7 @@ class Label(displayio.Group):
        """
 
     # pylint: disable=unused-argument, too-many-instance-attributes, too-many-locals, too-many-arguments
-    # pylint: disable=too-many-branches, no-self-use
+    # pylint: disable=too-many-branches, no-self-use, too-many-statements
     # Note: max_glyphs parameter is unnecessary, this is used for direct
     # compatibility with label.py
 
@@ -495,7 +495,7 @@ class Label(displayio.Group):
                             skip_index=0,  # do not copy over any 0 background pixels
                         )
 
-                    except:
+                    except AttributeError:
                         for y in range(my_glyph.height):
                             for x in range(my_glyph.width):
                                 x_placement = x + xposition + my_glyph.dx

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -111,29 +111,19 @@ class Label(displayio.Group):
         anchor_point=None,
         anchored_position=None,
         save_text=True,  # can reduce memory use if save_text = False
-        **kwargs
+        scale=1,
     ):
-
-        # Scale will be passed to Group using kwargs.
-        if "scale" in kwargs.keys():
-            scale = kwargs["scale"]
-            kwargs.pop(
-                "scale"
-            )  # Do not change scale of self Group, use this value to set scale of local_group
-        else:
-            scale = 1  # Set default scale=1
 
         # instance the Group
         # self Group will contain a single local_group which contains one TileGrid which contains
         # the text bitmap
         super().__init__(
-            max_size=1, x=x, y=y, **kwargs
+            max_size=1, x=x, y=y, 
         )  # this will include any arguments, including scale
 
         self.local_group = displayio.Group(
-            max_size=1, **kwargs
-        )  # local_group holds the tileGrid and
-        # sets the scaling
+            max_size=1, scale=scale
+        )  # local_group holds the tileGrid and sets the scaling
         self.append(
             self.local_group
         )  # the local_group will always stay in the self Group
@@ -165,7 +155,6 @@ class Label(displayio.Group):
             anchored_position=anchored_position,
             save_text=save_text,
             scale=scale,
-            **kwargs,
         )
 
     def _reset_text(
@@ -184,7 +173,6 @@ class Label(displayio.Group):
         anchored_position=None,
         save_text=None,
         scale=None,
-        **kwargs
     ):
 
         # Store all the instance variables

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -450,20 +450,58 @@ class Label(displayio.Group):
                     )  # for type BuiltinFont, this creates the x-offset in the glyph bitmap.
                        # for BDF loaded fonts, this should equal 0
 
-                    bitmap.blit(
-                        xposition + my_glyph.dx,
-                        yposition - my_glyph.height - my_glyph.dy,
-                        my_glyph.bitmap,
-                        x1=glyph_offset_x,
-                        y1=0,
-                        x2=glyph_offset_x + my_glyph.width - 1,
-                        y2=0 + my_glyph.height - 1,
-                        skip_index=0, # do not copy over any 0 background pixels
-                    )
+                    try:
+                        bitmap.blit(
+                            xposition + my_glyph.dx,
+                            yposition - my_glyph.height - my_glyph.dy,
+                            my_glyph.bitmap,
+                            x1=glyph_offset_x,
+                            y1=0,
+                            x2=glyph_offset_x + my_glyph.width - 1,
+                            y2=0 + my_glyph.height - 1,
+                            skip_index=0, # do not copy over any 0 background pixels
+                        )
+
+                    except:
+                        for y in range(my_glyph.height):
+                            for x in range(my_glyph.width):
+                                x_placement = x + xposition + my_glyph.dx
+                                y_placement = y + yposition - my_glyph.height - my_glyph.dy
+
+                                if (bitmap_width > x_placement >= 0) and (
+                                    bitmap_height > y_placement >= 0
+                                ):
+
+                                    # Allows for remapping the bitmap indexes using paletteIndex
+                                    # for background and text.
+                                    palette_indexes = (
+                                        background_palette_index,
+                                        text_palette_index,
+                                    )
+
+                                    this_pixel_color = palette_indexes[
+                                        my_glyph.bitmap[
+                                            y * my_glyph.bitmap.width + x + glyph_offset_x
+                                        ]
+                                    ]
+
+                                    if not print_only_pixels or this_pixel_color > 0:
+                                        # write all characters if printOnlyPixels = False,
+                                        # or if thisPixelColor is > 0
+                                        bitmap[
+                                            y_placement * bitmap_width + x_placement
+                                        ] = this_pixel_color
+                                elif y_placement > bitmap_height:
+                                    break
 
                     xposition = xposition + my_glyph.shift_x
 
         return (left, top, right - left, bottom - top)  # bounding_box
+
+
+
+
+
 
     @property
     def bounding_box(self):

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -98,8 +98,8 @@ class Label(displayio.Group):
         x=0,
         y=0,
         text="",
-        max_glyphs=None,    # This input parameter is ignored, only present for compatibility
-                            # with label.py
+        max_glyphs=None,  # This input parameter is ignored, only present for compatibility
+        # with label.py
         color=0xFFFFFF,
         background_color=None,
         line_spacing=1.25,
@@ -114,22 +114,31 @@ class Label(displayio.Group):
         **kwargs
     ):
 
-
         # Scale will be passed to Group using kwargs.
         if "scale" in kwargs.keys():
             scale = kwargs["scale"]
-            kwargs.pop("scale") # Do not change scale of self Group, use this value to set scale of local_group
+            kwargs.pop(
+                "scale"
+            )  # Do not change scale of self Group, use this value to set scale of
+            # local_group
 
         # instance the Group
-        # self Group will contain a single local_group which contains one TileGrid which contains the text bitmap
+        # self Group will contain a single local_group which contains one TileGrid which contains
+        # the text bitmap
         super().__init__(
             max_size=1, x=x, y=y, **kwargs
         )  # this will include any arguments, including scale
 
-        self.local_group=displayio.Group(max_size=1, **kwargs) # local_group holds the tileGrid and sets the scaling
-        self.append(self.local_group) # the local_group will always stay in the self Group
+        self.local_group = displayio.Group(
+            max_size=1, **kwargs
+        )  # local_group holds the tileGrid and
+        # sets the scaling
+        self.append(
+            self.local_group
+        )  # the local_group will always stay in the self Group
 
         self._font = font
+        self._text = text
 
         # Create the two-color palette
         self.palette = displayio.Palette(2)
@@ -140,23 +149,23 @@ class Label(displayio.Group):
         self._anchored_position = anchored_position
 
         # call the text updater with all the arguments.
-        self._reset_text(font=font, 
-                    x=x, 
-                    y=y, 
-                    text=text, 
-                    line_spacing=line_spacing,
-                    background_tight=background_tight,
-                    padding_top=padding_top,
-                    padding_bottom=padding_bottom,
-                    padding_left=padding_left,
-                    padding_right=padding_right,
-                    anchor_point=anchor_point,
-                    anchored_position=anchored_position,
-                    save_text=save_text,
-                    scale=scale,
-                    **kwargs,
-                    )
-
+        self._reset_text(
+            font=font,
+            x=x,
+            y=y,
+            text=text,
+            line_spacing=line_spacing,
+            background_tight=background_tight,
+            padding_top=padding_top,
+            padding_bottom=padding_bottom,
+            padding_left=padding_left,
+            padding_right=padding_right,
+            anchor_point=anchor_point,
+            anchored_position=anchored_position,
+            save_text=save_text,
+            scale=scale,
+            **kwargs,
+        )
 
     def _reset_text(
         self,
@@ -175,7 +184,7 @@ class Label(displayio.Group):
         save_text=None,
         scale=None,
         **kwargs
-        ):
+    ):
 
         # Store all the instance variables
         if font is not None:
@@ -202,8 +211,10 @@ class Label(displayio.Group):
             self._anchored_position = anchored_position
         if save_text is not None:
             self._save_text = save_text
-        if scale is not None: # Scale will be defined in local_group (Note: self should have scale=1)
-            self.scale=scale  # call the setter
+        if (
+            scale is not None
+        ):  # Scale will be defined in local_group (Note: self should have scale=1)
+            self.scale = scale  # call the setter
 
         # if text is not provided as a parameter (text is None), use the previous value.
         if (text is None) and self._save_text:
@@ -214,22 +225,23 @@ class Label(displayio.Group):
         else:
             self._text = None  # save a None value since text string is not saved
 
-
         # Check for empty string
-        if (text == "") or (text is None): # If empty string, just create a zero-sized bounding box and that's it.
+        if (text == "") or (
+            text is None
+        ):  # If empty string, just create a zero-sized bounding box and that's it.
 
             self._bounding_box = (
-                                0,
-                                0,
-                                0, # zero width with text == ""
-                                0, # zero height with text == ""
-                                )
+                0,
+                0,
+                0,  # zero width with text == ""
+                0,  # zero height with text == ""
+            )
             # Clear out any items in the self Group, in case this is an update to the bitmap_label
-            for item in self:
+            for _ in self:
                 self.pop(0)
 
-        else: # The text string is not empty, so create the Bitmap and TileGrid and append to the self Group
-
+        else:  # The text string is not empty, so create the Bitmap and TileGrid and
+            # append to the self Group
 
             # Calculate the text bounding box
 
@@ -241,19 +253,19 @@ class Label(displayio.Group):
                 x_offset,
                 tight_y_offset,
                 loose_box_y,
-                loose_y_offset
+                loose_y_offset,
             ) = self._text_bounding_box(
                 text, self._font, self._line_spacing,
-            ) # calculate the box size for a tight and loose backgrounds
+            )  # calculate the box size for a tight and loose backgrounds
 
-            if self._background_tight: 
+            if self._background_tight:
                 box_y = tight_box_y
                 y_offset = tight_y_offset
 
-            else: # calculate the box size for a loose background
+            else:  # calculate the box size for a loose background
                 box_y = loose_box_y
                 y_offset = loose_y_offset
-                
+
             # Calculate the background size including padding
             box_x = box_x + self._padding_left + self._padding_right
             box_y = box_y + self._padding_top + self._padding_bottom
@@ -287,10 +299,13 @@ class Label(displayio.Group):
                 y=label_position_yoffset - y_offset - self._padding_top,
             )
 
-            # Clear out any items in the local_group Group, in case this is an update to the bitmap_label
-            for item in self.local_group:
+            # Clear out any items in the local_group Group, in case this is an update to
+            # the bitmap_label
+            for _ in self.local_group:
                 self.local_group.pop(0)
-            self.local_group.append(self.tilegrid)  # add the bitmap's tilegrid to the group
+            self.local_group.append(
+                self.tilegrid
+            )  # add the bitmap's tilegrid to the group
 
             # Update bounding_box values.  Note: To be consistent with label.py,
             # this is the bounding box for the text only, not including the background.
@@ -303,7 +318,8 @@ class Label(displayio.Group):
 
         self.anchored_position = (
             self._anchored_position
-        )  # set the anchored_position with setter after bitmap is created, sets the x,y positions of the label
+        )  # set the anchored_position with setter after bitmap is created, sets the
+        # x,y positions of the label
 
     @staticmethod
     def _line_spacing_ypixels(font, line_spacing):
@@ -383,18 +399,24 @@ class Label(displayio.Group):
 
         final_box_width = right - left
 
-
         final_box_height_tight = bottom - top
         final_y_offset_tight = -top + y_offset_tight
 
         final_box_height_loose = (lines - 1) * self._line_spacing_ypixels(
-                font, line_spacing
-                ) + (ascender_max + descender_max)
+            font, line_spacing
+        ) + (ascender_max + descender_max)
         final_y_offset_loose = ascender_max
 
         # return (final_box_width, final_box_height, left, final_y_offset)
 
-        return (final_box_width, final_box_height_tight, left, final_y_offset_tight, final_box_height_loose, final_y_offset_loose)
+        return (
+            final_box_width,
+            final_box_height_tight,
+            left,
+            final_y_offset_tight,
+            final_box_height_loose,
+            final_y_offset_loose,
+        )
 
     # pylint: disable=too-many-nested-blocks
     def _place_text(
@@ -459,7 +481,7 @@ class Label(displayio.Group):
                     glyph_offset_x = (
                         my_glyph.tile_index * my_glyph.width
                     )  # for type BuiltinFont, this creates the x-offset in the glyph bitmap.
-                       # for BDF loaded fonts, this should equal 0
+                    # for BDF loaded fonts, this should equal 0
 
                     try:
                         bitmap.blit(
@@ -470,14 +492,16 @@ class Label(displayio.Group):
                             y1=0,
                             x2=glyph_offset_x + my_glyph.width,
                             y2=0 + my_glyph.height,
-                            skip_index=0, # do not copy over any 0 background pixels
+                            skip_index=0,  # do not copy over any 0 background pixels
                         )
 
                     except:
                         for y in range(my_glyph.height):
                             for x in range(my_glyph.width):
                                 x_placement = x + xposition + my_glyph.dx
-                                y_placement = y + yposition - my_glyph.height - my_glyph.dy
+                                y_placement = (
+                                    y + yposition - my_glyph.height - my_glyph.dy
+                                )
 
                                 if (bitmap_width > x_placement >= 0) and (
                                     bitmap_height > y_placement >= 0
@@ -492,7 +516,9 @@ class Label(displayio.Group):
 
                                     this_pixel_color = palette_indexes[
                                         my_glyph.bitmap[
-                                            y * my_glyph.bitmap.width + x + glyph_offset_x
+                                            y * my_glyph.bitmap.width
+                                            + x
+                                            + glyph_offset_x
                                         ]
                                     ]
 
@@ -519,12 +545,12 @@ class Label(displayio.Group):
     def scale(self):
         """Set the scaling of the label"""
         return self._scale
-    
+
     @scale.setter
     def scale(self, new_scale):
-        self.local_group.scale=new_scale
-        self._scale=new_scale
-        self.anchored_position=self._anchored_position # update the anchored_position
+        self.local_group.scale = new_scale
+        self._scale = new_scale
+        self.anchored_position = self._anchored_position  # update the anchored_position
 
     @property
     def line_spacing(self):
@@ -538,7 +564,6 @@ class Label(displayio.Group):
             self._reset_text(line_spacing=new_line_spacing)
         else:
             raise RuntimeError("line_spacing is immutable when save_text is False")
-
 
     @property
     def color(self):
@@ -575,17 +600,18 @@ class Label(displayio.Group):
         """Text to displayed."""
         return self._text
 
-    @text.setter # Cannot set color or background color with text setter, use separate setter
+    @text.setter  # Cannot set color or background color with text setter, use separate setter
     def text(self, new_text):
         self._reset_text(text=new_text)
 
     @property
     def font(self):
         """Font to use for text display."""
-        return self.font
+        return self._font
 
     @font.setter
     def font(self, new_font):
+        self._font = new_font
         if self._save_text:
             self._reset_text(font=new_font)
         else:

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -118,7 +118,7 @@ class Label(displayio.Group):
         # self Group will contain a single local_group which contains one TileGrid which contains
         # the text bitmap
         super().__init__(
-            max_size=1, x=x, y=y, 
+            max_size=1, x=x, y=y,
         )  # this will include any arguments, including scale
 
         self.local_group = displayio.Group(

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -400,6 +400,10 @@ class Label(displayio.Group):
         yposition,
         text_palette_index=1,
         background_palette_index=0,
+        print_only_pixels=True,  # print_only_pixels = True: only update the bitmap where the glyph
+        # pixel color is > 0.  This is especially useful for script fonts where glyph
+        # bounding boxes overlap
+        # Set `print_only_pixels=False` to write all pixels
     ):
         # placeText - Writes text into a bitmap at the specified location.
         #
@@ -514,10 +518,16 @@ class Label(displayio.Group):
     #     return self._scale
     
     # @scale.setter
+    # #@displayio.Group.scale.setter
     # def scale(self, new_scale):
     #     self._scale=new_scale
     #     #super(displayio.Group, self).scale.fset(self, new_scale)
-    #     anchored_position=self._anchored_position # update the anchored_position
+    #     self.anchored_position=self._anchored_position # update the anchored_position
+    #     #displayio.Group.scale.__set__(self, new_scale)
+    #     #displayio.Group.scale=new_scale
+    #     #setattr(super(), "scale", new_scale)
+    #     #setattr(self, "scale", new_scale)
+    #     super(displayio.Group, self).scale.__set__(self, new_scale)
 
     def set_scale(self, new_scale):
         """Set the scaling of the label"""

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -119,8 +119,9 @@ class Label(displayio.Group):
             scale = kwargs["scale"]
             kwargs.pop(
                 "scale"
-            )  # Do not change scale of self Group, use this value to set scale of
-            # local_group
+            )  # Do not change scale of self Group, use this value to set scale of local_group
+        else:
+            scale = 1  # Set default scale=1
 
         # instance the Group
         # self Group will contain a single local_group which contains one TileGrid which contains

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -79,18 +79,16 @@ class Label(displayio.Group):
         padding_right=0,
         anchor_point=None,
         anchored_position=None,
-        **kwargs
+        scale=1,
     ):
-        if "scale" in kwargs.keys():
-            self._scale = kwargs["scale"]
-        else:
-            self._scale = 1
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
         if not max_glyphs:
             max_glyphs = len(text)
         # add one to max_size for the background bitmap tileGrid
-        super().__init__(max_size=max_glyphs + 1, **kwargs)
+        super().__init__(max_size=1)
+        self.local_group=displayio.Group(max_size=max_glyphs + 1, scale=scale)
+        self.append(self.local_group)
 
         self.width = max_glyphs
         self._font = font
@@ -121,11 +119,14 @@ class Label(displayio.Group):
         self._padding_bottom = padding_bottom
         self._padding_left = padding_left
         self._padding_right = padding_right
+        
+        self._scale=scale
 
         if text is not None:
             self._update_text(str(text))
         if (anchored_position is not None) and (anchor_point is not None):
             self.anchored_position = anchored_position
+
 
     def _create_background_box(self, lines, y_offset):
 
@@ -172,6 +173,8 @@ class Label(displayio.Group):
             y=y_box_offset,
         )
 
+
+
         return tile_grid
 
     def _update_background_color(self, new_color):
@@ -179,7 +182,7 @@ class Label(displayio.Group):
         if new_color is None:
             self._background_palette.make_transparent(0)
             if self._added_background_tilegrid:
-                self.pop(0)
+                self.local_group.pop(0)
                 self._added_background_tilegrid = False
         else:
             self._background_palette.make_opaque(0)
@@ -200,10 +203,10 @@ class Label(displayio.Group):
                     self._boundingbox[3] + self._padding_top + self._padding_bottom > 0
                 )
             ):
-                if len(self) > 0:
-                    self.insert(0, self._create_background_box(lines, y_offset))
+                if len(self.local_group) > 0: # This can be simplified in CP v6.0, when group.append(0) bug is corrected
+                    self.local_group.insert(0, self._create_background_box(lines, y_offset))
                 else:
-                    self.append(self._create_background_box(lines, y_offset))
+                    self.local_group.append(self._create_background_box(lines, y_offset))
                 self._added_background_tilegrid = True
 
         else:  # a bitmap is present in the self Group
@@ -217,9 +220,9 @@ class Label(displayio.Group):
                     self._boundingbox[3] + self._padding_top + self._padding_bottom > 0
                 )
             ):
-                self[0] = self._create_background_box(lines, y_offset)
+                self.local_group[0] = self._create_background_box(lines, y_offset)
             else:  # delete the existing bitmap
-                self.pop(0)
+                self.local_group.pop(0)
                 self._added_background_tilegrid = False
 
     def _update_text(
@@ -284,10 +287,10 @@ class Label(displayio.Group):
                         x=position_x,
                         y=position_y,
                     )
-                if tilegrid_count < len(self):
-                    self[tilegrid_count] = face
+                if tilegrid_count < len(self.local_group):
+                    self.local_group[tilegrid_count] = face
                 else:
-                    self.append(face)
+                    self.local_group.append(face)
                 tilegrid_count += 1
             x += glyph.shift_x
             i += 1
@@ -296,8 +299,8 @@ class Label(displayio.Group):
         if left is None:
             left = 0
 
-        while len(self) > tilegrid_count:  # i:
-            self.pop()
+        while len(self.local_group) > tilegrid_count:  # i:
+            self.local_group.pop()
         self._text = new_text
         self._boundingbox = (left, top, right - left, bottom - top)
 
@@ -319,6 +322,7 @@ class Label(displayio.Group):
     @line_spacing.setter
     def line_spacing(self, spacing):
         self._line_spacing = spacing
+        self.text=self._text # redraw the box
 
     @property
     def color(self):
@@ -357,6 +361,19 @@ class Label(displayio.Group):
             self.anchored_position = current_anchored_position
         except RuntimeError as run_error:
             raise RuntimeError("Text length exceeds max_glyphs") from run_error
+
+    @property
+    def scale(self):
+        return self._scale
+
+    @scale.setter
+    def scale(self, new_scale):
+        current_anchored_position=self.anchored_position
+        self._scale=new_scale
+        self.local_group.scale=new_scale
+        self.anchored_position=current_anchored_position
+
+    
 
     @property
     def font(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -87,7 +87,7 @@ class Label(displayio.Group):
             max_glyphs = len(text)
         # add one to max_size for the background bitmap tileGrid
         super().__init__(max_size=1)
-        self.local_group=displayio.Group(max_size=max_glyphs + 1, scale=scale)
+        self.local_group = displayio.Group(max_size=max_glyphs + 1, scale=scale)
         self.append(self.local_group)
 
         self.width = max_glyphs
@@ -119,14 +119,13 @@ class Label(displayio.Group):
         self._padding_bottom = padding_bottom
         self._padding_left = padding_left
         self._padding_right = padding_right
-        
-        self._scale=scale
+
+        self._scale = scale
 
         if text is not None:
             self._update_text(str(text))
         if (anchored_position is not None) and (anchor_point is not None):
             self.anchored_position = anchored_position
-
 
     def _create_background_box(self, lines, y_offset):
 
@@ -173,8 +172,6 @@ class Label(displayio.Group):
             y=y_box_offset,
         )
 
-
-
         return tile_grid
 
     def _update_background_color(self, new_color):
@@ -203,10 +200,16 @@ class Label(displayio.Group):
                     self._boundingbox[3] + self._padding_top + self._padding_bottom > 0
                 )
             ):
-                if len(self.local_group) > 0: # This can be simplified in CP v6.0, when group.append(0) bug is corrected
-                    self.local_group.insert(0, self._create_background_box(lines, y_offset))
+                if (
+                    len(self.local_group) > 0
+                ):  # This can be simplified in CP v6.0, when group.append(0) bug is corrected
+                    self.local_group.insert(
+                        0, self._create_background_box(lines, y_offset)
+                    )
                 else:
-                    self.local_group.append(self._create_background_box(lines, y_offset))
+                    self.local_group.append(
+                        self._create_background_box(lines, y_offset)
+                    )
                 self._added_background_tilegrid = True
 
         else:  # a bitmap is present in the self Group
@@ -322,7 +325,7 @@ class Label(displayio.Group):
     @line_spacing.setter
     def line_spacing(self, spacing):
         self._line_spacing = spacing
-        self.text=self._text # redraw the box
+        self.text = self._text  # redraw the box
 
     @property
     def color(self):
@@ -364,16 +367,15 @@ class Label(displayio.Group):
 
     @property
     def scale(self):
+        """Set the scaling of the label, in integer values"""
         return self._scale
 
     @scale.setter
     def scale(self, new_scale):
-        current_anchored_position=self.anchored_position
-        self._scale=new_scale
-        self.local_group.scale=new_scale
-        self.anchored_position=current_anchored_position
-
-    
+        current_anchored_position = self.anchored_position
+        self._scale = new_scale
+        self.local_group.scale = new_scale
+        self.anchored_position = current_anchored_position
 
     @property
     def font(self):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -80,14 +80,23 @@ class Label(displayio.Group):
         anchor_point=None,
         anchored_position=None,
         scale=1,
+        **kwargs
     ):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
         if not max_glyphs:
             max_glyphs = len(text)
         # add one to max_size for the background bitmap tileGrid
-        super().__init__(max_size=1)
-        self.local_group = displayio.Group(max_size=max_glyphs + 1, scale=scale)
+
+        # instance the Group
+        # self Group will contain a single local_group which contains a Group (self.local_group)
+        # which contains a TileGrid
+        super().__init__(
+            max_size=1, scale=1, **kwargs
+        )  # The self scale should always be 1
+        self.local_group = displayio.Group(
+            max_size=max_glyphs + 1, scale=scale
+        )  # local_group will set the scale
         self.append(self.local_group)
 
         self.width = max_glyphs

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,3 +6,6 @@
 
 .. automodule:: adafruit_display_text.label
    :members:
+
+.. automodule:: adafruit_display_text.bitmap_label
+   :members:


### PR DESCRIPTION
### `bitmap_label` updates
This update makes `text`, `line_spacing` and `scale` mutable.

Other changes:
- Add option to use `bitmap.blit` on CircuitPython builds where the function is available, but will default back to Python blit when not available

Other details on the changes are in a separate post below.