### PR TITLE
Add matrixportal example

### DIFF
--- a/examples/display_text_matrixportal.py
+++ b/examples/display_text_matrixportal.py
@@ -1,0 +1,23 @@
+"""
+This example shows how to create a display_text label and show it
+with a Matrix Portal
+
+Requires:
+adafruit_matrixportal - https://github.com/adafruit/Adafruit_CircuitPython_MatrixPortal
+
+Copy it from the current libraries bundle into the lib folder on your device.
+"""
+import terminalio
+from adafruit_matrixportal.matrix import Matrix
+from adafruit_display_text import label
+
+matrix = Matrix()
+display = matrix.display
+
+text = "Hello\nworld"
+text_area = label.Label(terminalio.FONT, text=text)
+text_area.x = 1
+text_area.y = 4
+display.show(text_area)
+while True:
+    pass


### PR DESCRIPTION
Lots of folks have a Matrix Portal now and are possibly being introduced to `displayio` for the first time with it. See #95 for one example. But I think it's popped up a few other places as well. 

The majority of `displayio` examples are written using `board.DISPLAY` assuming that they will be run on a device with a built-in display. Any written this way won't work as is on a Matrix Portal.

This PR adds a copy of the simpletest example that has been modified to work on Matrix Portal.

I do wonder if we want to keep the examples seperated like in this PR, or combined into one file with comment / uncomment a section? Or perhaps there is some other possible technical solution that can work with both types of devices without the user having to worry about it as much?