### PR TITLE
Correct bug of modifying self rather than self.local_group when text …

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -228,9 +228,9 @@ class Label(displayio.Group):
                 0,  # zero width with text == ""
                 0,  # zero height with text == ""
             )
-            # Clear out any items in the self Group, in case this is an update to the bitmap_label
-            for _ in self:
-                self.pop(0)
+            # Clear out any items in the self.local_group Group, in case this is an update to the bitmap_label
+            for _ in self.local_group:
+                self.local_group.pop(0)
 
         else:  # The text string is not empty, so create the Bitmap and TileGrid and
             # append to the self Group

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -228,7 +228,8 @@ class Label(displayio.Group):
                 0,  # zero width with text == ""
                 0,  # zero height with text == ""
             )
-            # Clear out any items in the self.local_group Group, in case this is an update to the bitmap_label
+            # Clear out any items in the self.local_group Group, in case this is an
+            # update to the bitmap_label
             for _ in self.local_group:
                 self.local_group.pop(0)
 


### PR DESCRIPTION
…is blank


This was a bug that was introduced when the separate self and self.local_group was added to handle modifying the scaling on the fly.

The bug was when the text was "" and it actually was modifying the self group rather than the self.local_group. Pull request is incoming.

Resolves issue #97 