### PR TITLE
label: Use new, optional 'ascent', 'descent' properties

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -66,24 +66,24 @@ class Label(displayio.Group):
          Must include a capital M for measuring character size.
        :param str text: Text to display
        :param int max_glyphs: Unnecessary parameter (provided only for direct compability
-       with label.py)
+         with label.py)
        :param int color: Color of all text in RGB hex
        :param int background_color: Color of the background, use `None` for transparent
        :param double line_spacing: Line spacing of text to display
        :param boolean background_tight: Set `True` only if you want background box to tightly
-       surround text
+         surround text
        :param int padding_top: Additional pixels added to background bounding box at top
        :param int padding_bottom: Additional pixels added to background bounding box at bottom
        :param int padding_left: Additional pixels added to background bounding box at left
        :param int padding_right: Additional pixels added to background bounding box at right
        :param (double,double) anchor_point: Point that anchored_position moves relative to.
-        Tuple with decimal percentage of width and height.
-        (E.g. (0,0) is top left, (1.0, 0.5): is middle right.)
+         Tuple with decimal percentage of width and height.
+         (E.g. (0,0) is top left, (1.0, 0.5): is middle right.)
        :param (int,int) anchored_position: Position relative to the anchor_point. Tuple
-       containing x,y pixel coordinates.
+         containing x,y pixel coordinates.
        :param int scale: Integer value of the pixel scaling
        :param bool save_text: Set True to save the text string as a constant in the
-        label structure.  Set False to reduce memory use.
+         label structure.  Set False to reduce memory use.
        """
 
     # pylint: disable=unused-argument, too-many-instance-attributes, too-many-locals, too-many-arguments

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -147,28 +147,17 @@ class Label(displayio.Group):
             y_box_offset = self._boundingbox[1]
 
         else:  # draw a "loose" bounding box to include any ascenders/descenders.
-
-            # check a few glyphs for maximum ascender and descender height
-            # Enhancement: it would be preferred to access the font "FONT_ASCENT" and
-            # "FONT_DESCENT" in the imported BDF file
-            glyphs = "M j'"  # choose glyphs with highest ascender and lowest
-            # descender, will depend upon font used
-            ascender_max = descender_max = 0
-            for char in glyphs:
-                this_glyph = self._font.get_glyph(ord(char))
-                if this_glyph:
-                    ascender_max = max(ascender_max, this_glyph.height + this_glyph.dy)
-                    descender_max = max(descender_max, -this_glyph.dy)
+            ascent, descent = self._get_ascent_descent()
 
             box_width = self._boundingbox[2] + self._padding_left + self._padding_right
             x_box_offset = -self._padding_left
             box_height = (
-                (ascender_max + descender_max)
+                (ascent + descent)
                 + int((lines - 1) * self.height * self._line_spacing)
                 + self._padding_top
                 + self._padding_bottom
             )
-            y_box_offset = -ascender_max + y_offset - self._padding_top
+            y_box_offset = -ascent + y_offset - self._padding_top
 
         box_width = max(0, box_width)  # remove any negative values
         box_height = max(0, box_height)  # remove any negative values
@@ -183,6 +172,25 @@ class Label(displayio.Group):
 
         return tile_grid
 
+    def _get_ascent_descent(self):
+        if hasattr(self.font, "ascent"):
+            return self.font.ascent, self.font.descent
+
+        # check a few glyphs for maximum ascender and descender height
+        glyphs = "M j'"  # choose glyphs with highest ascender and lowest
+        self._font.load_glyphs(glyphs)
+        # descender, will depend upon font used
+        ascender_max = descender_max = 0
+        for char in glyphs:
+            this_glyph = self._font.get_glyph(ord(char))
+            if this_glyph:
+                ascender_max = max(ascender_max, this_glyph.height + this_glyph.dy)
+                descender_max = max(descender_max, -this_glyph.dy)
+        return ascender_max, descender_max
+
+    def _get_ascent(self):
+        return self._get_ascent_descent()[0]
+
     def _update_background_color(self, new_color):
 
         if new_color is None:
@@ -196,7 +204,7 @@ class Label(displayio.Group):
         self._background_color = new_color
 
         lines = self._text.rstrip("\n").count("\n") + 1
-        y_offset = int((self._font.get_glyph(ord("M")).height) / 2)
+        y_offset = self._get_ascent() // 2
 
         if not self._added_background_tilegrid:  # no bitmap is in the self Group
             # add bitmap if text is present and bitmap sizes > 0 pixels
@@ -248,13 +256,7 @@ class Label(displayio.Group):
             i = 0
         tilegrid_count = i
 
-        try:
-            self._font.load_glyphs(new_text + "M")
-        except AttributeError:
-            # ignore if font does not have load_glyphs
-            pass
-
-        y_offset = int((self._font.get_glyph(ord("M")).height) / 2)
+        y_offset = self._get_ascent() // 2
 
         right = top = bottom = 0
         left = None

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -178,7 +178,11 @@ class Label(displayio.Group):
 
         # check a few glyphs for maximum ascender and descender height
         glyphs = "M j'"  # choose glyphs with highest ascender and lowest
-        self._font.load_glyphs(glyphs)
+        try:
+            self._font.load_glyphs(glyphs)
+        except AttributeError:
+            # Builtin font doesn't have or need load_glyphs
+            pass
         # descender, will depend upon font used
         ascender_max = descender_max = 0
         for char in glyphs:


### PR DESCRIPTION
Each time new glyphs have to be loaded from a font, it can take a long time (hundreds of milliseconds).  Besides which, not all fonts have the "M" character that is used for estimating the ascent.  Instead, use the ascent and descent properties of Font objects, if available. (they are available in bdf and pcf fonts since https://github.com/adafruit/Adafruit_CircuitPython_Bitmap_Font/releases/tag/1.3.0 but terminalio.FONT still doesn't have it)

In particular, before this change the "forkawesome" fonts can't be used, because they have only glyphs starting at Unicode 0xf000 (called the Private Use Area), and may affect webdings/wingdings type fonts as well. (forkawesome fonts converted to pcf are [on my blog](https://emergent.unpythonic.net/01606790241))

This changes the layout of text slightly.  For instance, the height of the "M" glyph in GothamBlack-50.bdf is 35, but the Ascent of the font is 40 (and some characters, such as Å, are taller than the ascent at 45 pixels high).  So in this case, text may be shifted down by about 2 to 3 pixels (half of the difference between 35 and 40, as fonts are positioned vertically relative to the half ascent).

To test it, grab https://media.unpythonic.net/emergent-files/01606790241/forkawesome-36.pcf and run the following code (I used a pyportal titano):
```python
from displayio import Group

font = load_font("/forkawesome-36.pcf")
w,h,dx,dy = font.get_bounding_box()

glyphs = "".join(chr(0xf000 + i) for i in range(8))

group = Group()
label = Label(font=font, text=glyphs, background_color=0x111111)
label.anchor_point = (0, 0)
label.anchored_position = (0,0)

group.append(label)
board.DISPLAY.show(group)
while True:
    pass
```