### PR TITLE
Bitmap label ascent descent

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -325,7 +325,6 @@ class Label(displayio.Group):
     def _get_ascent(self):
         return self._get_ascent_descent()[0]
 
-
     @staticmethod
     def _line_spacing_ypixels(font, line_spacing):
         # Note: Scaling is provided at the Group level


### PR DESCRIPTION
This implements the changes required in `bitmap_label.py` to use the ascent and descent feature which was recently added to `Adafruit_CircuitPython_Bitmap_Font`

The analogous PR for the regular label was #102 

I tested on a PyPortal with this code:
```python
import board
from displayio import Group
from adafruit_display_text import bitmap_label
from adafruit_bitmap_font import bitmap_font

font = bitmap_font.load_font("/fonts/forkawesome-36.pcf")
w,h,dx,dy = font.get_bounding_box()

glyphs = "".join(chr(0xf000 + i) for i in range(8))

group = Group()
label = bitmap_label.Label(font=font, text=glyphs, background_color=0x111111)
label.anchor_point = (0, 0)
label.anchored_position = (0,0)

group.append(label)
board.DISPLAY.show(group)
while True:
    pass
```