### PR TITLE
Adding the wrap_by_pixels function

### DIFF
--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -41,10 +41,7 @@ def wrap_text_to_pixels(string, max_width, font=None, indent0="", indent1=""):
     swidth = measure(" ")
     firstword = True
     for line_in_input in string.split("\n"):
-
-        print("line: {}".format(line_in_input))
         for index, word in enumerate(line_in_input.split(" ")):
-            print("word: {}".format(word))
             wwidth = measure(word)
             word_parts = []
             cur_part = ""

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -40,41 +40,52 @@ def wrap_text_to_pixels(string, max_width, font=None, indent0="", indent1=""):
     width = measure(indent0)
     swidth = measure(" ")
     firstword = True
-    for word in string.split():
-        wwidth = measure(word)
-        word_parts = []
-        cur_part = ""
-        if wwidth > max_width:
-            if partial:
-                lines.append("".join(partial))
-                partial = []
-            for char in word:
-                if measure(cur_part) + measure(char) + measure("-") > max_width:
-                    word_parts.append(cur_part + "-")
-                    cur_part = char
-                else:
-                    cur_part += char
-            if cur_part:
-                word_parts.append(cur_part)
-            for line in word_parts[:-1]:
-                lines.append(line)
-            partial.append(word_parts[-1])
-            width = measure(word_parts[-1])
-            if firstword:
-                firstword = False
-        else:
-            if firstword:
-                partial.append(word)
-                firstword = False
-                width += wwidth
-            elif width + swidth + wwidth < max_width:
-                partial.append(" ")
-                partial.append(word)
-                width += wwidth + swidth
+    for line_in_input in string.split("\n"):
+
+        print("line: {}".format(line_in_input))
+        for index, word in enumerate(line_in_input.split(" ")):
+            print("word: {}".format(word))
+            wwidth = measure(word)
+            word_parts = []
+            cur_part = ""
+
+            if wwidth > max_width:
+                if partial:
+                    lines.append("".join(partial))
+                    partial = []
+                for char in word:
+                    if measure(cur_part) + measure(char) + measure("-") > max_width:
+                        word_parts.append(cur_part + "-")
+                        cur_part = char
+                    else:
+                        cur_part += char
+                if cur_part:
+                    word_parts.append(cur_part)
+                for line in word_parts[:-1]:
+                    lines.append(line)
+                partial.append(word_parts[-1])
+                width = measure(word_parts[-1])
+                if firstword:
+                    firstword = False
             else:
-                lines.append("".join(partial))
-                partial = [indent1, word]
-                width = measure(indent1) + wwidth
+                if firstword:
+                    partial.append(word)
+                    firstword = False
+                    width += wwidth
+                elif width + swidth + wwidth < max_width:
+                    if index > 0:
+                        partial.append(" ")
+                    partial.append(word)
+                    width += wwidth + swidth
+                else:
+                    lines.append("".join(partial))
+                    partial = [indent1, word]
+                    width = measure(indent1) + wwidth
+
+        lines.append("".join(partial))
+        partial = [indent1]
+        width = measure(indent1)
+
     if partial:
         lines.append("".join(partial))
     return lines

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -41,9 +41,7 @@ def wrap_text_to_pixels(string, max_width, font=None, indent0="", indent1=""):
     swidth = measure(" ")
     firstword = True
     for word in string.split():
-        # TODO: split words that are larger than max_width
         wwidth = measure(word)
-        print("{} - {}".format(word, wwidth))
         word_parts = []
         cur_part = ""
         if wwidth > max_width:
@@ -51,7 +49,6 @@ def wrap_text_to_pixels(string, max_width, font=None, indent0="", indent1=""):
                 lines.append("".join(partial))
                 partial = []
             for char in word:
-                # print(measure(cur_part) + measure(char) + measure("-"))
                 if measure(cur_part) + measure(char) + measure("-") > max_width:
                     word_parts.append(cur_part + "-")
                     cur_part = char
@@ -59,17 +56,13 @@ def wrap_text_to_pixels(string, max_width, font=None, indent0="", indent1=""):
                     cur_part += char
             if cur_part:
                 word_parts.append(cur_part)
-            # print(word_parts)
             for line in word_parts[:-1]:
                 lines.append(line)
             partial.append(word_parts[-1])
             width = measure(word_parts[-1])
             if firstword:
                 firstword = False
-            print("cur_width after splitword: {}".format(width))
-
         else:
-
             if firstword:
                 partial.append(word)
                 firstword = False
@@ -82,7 +75,6 @@ def wrap_text_to_pixels(string, max_width, font=None, indent0="", indent1=""):
                 lines.append("".join(partial))
                 partial = [indent1, word]
                 width = measure(indent1) + wwidth
-            print("cur_width: {}".format(width))
     if partial:
         lines.append("".join(partial))
     return "\n".join(lines)

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -7,27 +7,43 @@ Display Text module helper functions
 """
 
 
-def wrap_text_to_pixels(text, max_width, font=None, indent0="", indent1=""):
-    if font is None:
-        def measure(s):
-            return len(s)
-    else:
-        if hasattr(font, 'load_glyphs'):
-            font.load_glyphs(text)
+def wrap_text_to_pixels(string, max_width, font=None, indent0="", indent1=""):
+    """wrap_text_to_pixels function
+    A helper that will return a list of lines with word-break wrapping
 
-        def measure(s):
-            return sum(font.get_glyph(ord(c)).shift_x for c in s)
+    :param str string: The text to be wrapped.
+    :param int max_width: The maximum number of pixels on a line before wrapping.
+    :param Font font: The font to use for measuring the text.
+    :param str indent0: Additional character(s) to add to the first line.
+    :param str indent1: Additional character(s) to add to all other lines.
+
+
+    :return str lines: A string with newlines inserted appropriately to wrap
+      the input string at the given max_width in pixels
+
+    """
+    # pylint: disable=too-many-locals too-many-branches
+    if font is None:
+
+        def measure(string):
+            return len(string)
+
+    else:
+        if hasattr(font, "load_glyphs"):
+            font.load_glyphs(string)
+
+        def measure(string):
+            return sum(font.get_glyph(ord(c)).shift_x for c in string)
 
     lines = []
     partial = [indent0]
     width = measure(indent0)
-    swidth = measure(' ')
+    swidth = measure(" ")
     firstword = True
-    for word in text.split():
+    for word in string.split():
         # TODO: split words that are larger than max_width
         wwidth = measure(word)
         print("{} - {}".format(word, wwidth))
-        part_width = 0
         word_parts = []
         cur_part = ""
         if wwidth > max_width:
@@ -35,7 +51,7 @@ def wrap_text_to_pixels(text, max_width, font=None, indent0="", indent1=""):
                 lines.append("".join(partial))
                 partial = []
             for char in word:
-                #print(measure(cur_part) + measure(char) + measure("-"))
+                # print(measure(cur_part) + measure(char) + measure("-"))
                 if measure(cur_part) + measure(char) + measure("-") > max_width:
                     word_parts.append(cur_part + "-")
                     cur_part = char
@@ -43,7 +59,7 @@ def wrap_text_to_pixels(text, max_width, font=None, indent0="", indent1=""):
                     cur_part += char
             if cur_part:
                 word_parts.append(cur_part)
-            #print(word_parts)
+            # print(word_parts)
             for line in word_parts[:-1]:
                 lines.append(line)
             partial.append(word_parts[-1])
@@ -70,6 +86,7 @@ def wrap_text_to_pixels(text, max_width, font=None, indent0="", indent1=""):
     if partial:
         lines.append("".join(partial))
     return "\n".join(lines)
+
 
 def wrap_text_to_lines(string, max_chars):
     """wrap_text_to_lines function

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -47,13 +47,11 @@ def wrap_text_to_pixels(string, max_width, font=None, indent0="", indent1=""):
             cur_part = ""
 
             if wwidth > max_width:
-                if partial:
-                    lines.append("".join(partial))
-                    partial = []
                 for char in word:
-                    if measure(cur_part) + measure(char) + measure("-") > max_width:
-                        word_parts.append(cur_part + "-")
+                    if measure("".join(partial)) + measure(cur_part) + measure(char) + measure("-") > max_width:
+                        word_parts.append("".join(partial) + cur_part + "-")
                         cur_part = char
+                        partial = [indent1]
                     else:
                         cur_part += char
                 if cur_part:

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -48,7 +48,13 @@ def wrap_text_to_pixels(string, max_width, font=None, indent0="", indent1=""):
 
             if wwidth > max_width:
                 for char in word:
-                    if measure("".join(partial)) + measure(cur_part) + measure(char) + measure("-") > max_width:
+                    if (
+                        measure("".join(partial))
+                        + measure(cur_part)
+                        + measure(char)
+                        + measure("-")
+                        > max_width
+                    ):
                         word_parts.append("".join(partial) + cur_part + "-")
                         cur_part = char
                         partial = [indent1]

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 Tim C for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Tim C, 2021 Jeff Epler for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
 
@@ -6,6 +6,42 @@
 Display Text module helper functions
 """
 
+
+def wrap_text_to_pixels(text, max_width, font=None, indent0="", indent1=""):
+    if font is None:
+        def measure(s):
+            return len(s)
+    else:
+        if hasattr(font, 'load_glyphs'):
+            font.load_glyphs(text)
+
+        def measure(s):
+            return sum(font.get_glyph(ord(c)).shift_x for c in s)
+
+    lines = []
+    partial = [indent0]
+    width = measure(indent0)
+    swidth = measure(' ')
+    firstword = True
+    for word in text.split():
+        # TODO: split words that are larger than max_width
+        wwidth = measure(word)
+        print("{} - {}".format(word, wwidth))
+        if firstword:
+            partial.append(word)
+            firstword = False
+            width += wwidth
+        elif width + swidth + wwidth < max_width:
+            partial.append(" ")
+            partial.append(word)
+            width += wwidth + swidth
+        else:
+            lines.append("".join(partial))
+            partial = [indent1, word]
+            width = measure(indent1) + wwidth + swidth
+    if partial:
+        lines.append("".join(partial))
+    return "\n".join(lines)
 
 def wrap_text_to_lines(string, max_chars):
     """wrap_text_to_lines function

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -27,18 +27,46 @@ def wrap_text_to_pixels(text, max_width, font=None, indent0="", indent1=""):
         # TODO: split words that are larger than max_width
         wwidth = measure(word)
         print("{} - {}".format(word, wwidth))
-        if firstword:
-            partial.append(word)
-            firstword = False
-            width += wwidth
-        elif width + swidth + wwidth < max_width:
-            partial.append(" ")
-            partial.append(word)
-            width += wwidth + swidth
+        part_width = 0
+        word_parts = []
+        cur_part = ""
+        if wwidth > max_width:
+            if partial:
+                lines.append("".join(partial))
+                partial = []
+            for char in word:
+                #print(measure(cur_part) + measure(char) + measure("-"))
+                if measure(cur_part) + measure(char) + measure("-") > max_width:
+                    word_parts.append(cur_part + "-")
+                    cur_part = char
+                else:
+                    cur_part += char
+            if cur_part:
+                word_parts.append(cur_part)
+            #print(word_parts)
+            for line in word_parts[:-1]:
+                lines.append(line)
+            partial.append(word_parts[-1])
+            width = measure(word_parts[-1])
+            if firstword:
+                firstword = False
+            print("cur_width after splitword: {}".format(width))
+
         else:
-            lines.append("".join(partial))
-            partial = [indent1, word]
-            width = measure(indent1) + wwidth + swidth
+
+            if firstword:
+                partial.append(word)
+                firstword = False
+                width += wwidth
+            elif width + swidth + wwidth < max_width:
+                partial.append(" ")
+                partial.append(word)
+                width += wwidth + swidth
+            else:
+                lines.append("".join(partial))
+                partial = [indent1, word]
+                width = measure(indent1) + wwidth
+            print("cur_width: {}".format(width))
     if partial:
         lines.append("".join(partial))
     return "\n".join(lines)

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -18,8 +18,8 @@ def wrap_text_to_pixels(string, max_width, font=None, indent0="", indent1=""):
     :param str indent1: Additional character(s) to add to all other lines.
 
 
-    :return str lines: A string with newlines inserted appropriately to wrap
-      the input string at the given max_width in pixels
+    :return list lines: A list of the lines resulting from wrapping the
+      input text at max_width pixels size
 
     """
     # pylint: disable=too-many-locals too-many-branches
@@ -77,7 +77,7 @@ def wrap_text_to_pixels(string, max_width, font=None, indent0="", indent1=""):
                 width = measure(indent1) + wwidth
     if partial:
         lines.append("".join(partial))
-    return "\n".join(lines)
+    return lines
 
 
 def wrap_text_to_lines(string, max_chars):

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -90,8 +90,6 @@ def wrap_text_to_pixels(string, max_width, font=None, indent0="", indent1=""):
         partial = [indent1]
         width = measure(indent1)
 
-    if partial:
-        lines.append("".join(partial))
     return lines
 
 

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -9,7 +9,10 @@ Display Text module helper functions
 
 def wrap_text_to_pixels(string, max_width, font=None, indent0="", indent1=""):
     """wrap_text_to_pixels function
-    A helper that will return a list of lines with word-break wrapping
+    A helper that will return a list of lines with word-break wrapping.
+    Leading and trailing whitespace in your string will be removed. If
+    you wish to use leading whitespace see `indend0` and `indent1`
+    parameters.
 
     :param str string: The text to be wrapped.
     :param int max_width: The maximum number of pixels on a line before wrapping.

--- a/examples/display_text_wrap_pixels_test.py
+++ b/examples/display_text_wrap_pixels_test.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2021 Tim C, written for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+Test the wrap_text_to_pixels function. Try changing WRAP_WIDTH or text
+and observe the results. The red bar represents the full size of
+WRAP_WIDTH.
+"""
+
+import board
+import displayio
+import terminalio
+from adafruit_display_text import label, wrap_text_to_pixels
+
+WRAP_WIDTH = 140
+text = (
+    "CircuitPython is a programming language designed to simplify experimenting "
+    "and learning to code on low-cost microcontroller boards. "
+)
+
+# use built in display (PyPortal, PyGamer, PyBadge, CLUE, etc.)
+# see guide for setting up external displays (TFT / OLED breakouts, RGB matrices, etc.)
+# https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
+display = board.DISPLAY
+
+# Make the display context
+main_group = displayio.Group(max_size=10)
+display.show(main_group)
+
+font = terminalio.FONT
+
+print(text)
+print(display.width)
+
+text_area = label.Label(
+    font, text=wrap_text_to_pixels(text, WRAP_WIDTH, font), background_color=0x0000DD
+)
+
+text_area.anchor_point = (0, 0)
+text_area.anchored_position = (0, 0)
+
+main_group.append(text_area)
+
+# Create a bitmap with two colors
+size_checker = displayio.Bitmap(WRAP_WIDTH, 10, 2)
+# Create a two color palette
+palette = displayio.Palette(2)
+palette[0] = 0x0000DD
+palette[1] = 0xDD0000
+
+# Create a TileGrid using the Bitmap and Palette
+tile_grid = displayio.TileGrid(size_checker, pixel_shader=palette)
+
+tile_grid.y = text_area.bounding_box[1] + text_area.bounding_box[3] + 10
+
+size_checker.fill(1)
+
+main_group.append(tile_grid)
+
+while True:
+    pass

--- a/examples/display_text_wrap_pixels_test.py
+++ b/examples/display_text_wrap_pixels_test.py
@@ -33,7 +33,9 @@ print(text)
 print(display.width)
 
 text_area = label.Label(
-    font, text=wrap_text_to_pixels(text, WRAP_WIDTH, font), background_color=0x0000DD
+    font,
+    text="\n".join(wrap_text_to_pixels(text, WRAP_WIDTH, font)),
+    background_color=0x0000DD,
 )
 
 text_area.anchor_point = (0, 0)


### PR DESCRIPTION
Jeff wrote this nice helper function for wrapping text to a number of pixels instead of characters.

This PR adds that function as well as an example that illustrates it's usage.

One quirk worth consideration is that the new wrap_by_pixels function returns a string with newlines inserted. Whereas the older wrap_by_characters function returns a list of the lines, and joining with the newline is left up to the code using it. I think I like the way this one does it better with the string. But the other one came from the PyPortal libraries originally, perhaps there is something in them that is using the list. Maybe it would be worthwhile to add a parameter to both that controls this behavior?