### PR TITLE
check ascent for None before returning

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -304,10 +304,8 @@ class Label(displayio.Group):
 
     def _get_ascent_descent(self):
         if (
-            hasattr(self.font, "ascent")
-            and self.font.ascent
-            and hasattr(self.font, "descent")
-            and self.font.descent
+            getattr(self.font, "ascent") is not None and
+            getattr(self.font, "descent") is not None
         ):
             return self.font.ascent, self.font.descent
 

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -303,7 +303,12 @@ class Label(displayio.Group):
         # x,y positions of the label
 
     def _get_ascent_descent(self):
-        if hasattr(self.font, "ascent"):
+        if (
+            hasattr(self.font, "ascent")
+            and self.font.ascent
+            and hasattr(self.font, "descent")
+            and self.font.descent
+        ):
             return self.font.ascent, self.font.descent
 
         # check a few glyphs for maximum ascender and descender height

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -304,8 +304,8 @@ class Label(displayio.Group):
 
     def _get_ascent_descent(self):
         if (
-            getattr(self.font, "ascent") is not None and
-            getattr(self.font, "descent") is not None
+            getattr(self.font, "ascent") is not None
+            and getattr(self.font, "descent") is not None
         ):
             return self.font.ascent, self.font.descent
 

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -178,7 +178,12 @@ class Label(displayio.Group):
 
     def _get_ascent_descent(self):
         """ Private function to calculate ascent and descent font values """
-        if hasattr(self.font, "ascent") and self.font.ascent:
+        if (
+            hasattr(self.font, "ascent")
+            and self.font.ascent
+            and hasattr(self.font, "descent")
+            and self.font.descent
+        ):
             return self.font.ascent, self.font.descent
 
         # check a few glyphs for maximum ascender and descender height

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -179,10 +179,8 @@ class Label(displayio.Group):
     def _get_ascent_descent(self):
         """ Private function to calculate ascent and descent font values """
         if (
-            hasattr(self.font, "ascent")
-            and self.font.ascent
-            and hasattr(self.font, "descent")
-            and self.font.descent
+                getattr(self.font, "ascent") is not None and
+                getattr(self.font, "descent") is not None
         ):
             return self.font.ascent, self.font.descent
 

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -178,7 +178,7 @@ class Label(displayio.Group):
 
     def _get_ascent_descent(self):
         """ Private function to calculate ascent and descent font values """
-        if hasattr(self.font, "ascent"):
+        if hasattr(self.font, "ascent") and self.font.ascent:
             return self.font.ascent, self.font.descent
 
         # check a few glyphs for maximum ascender and descender height

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -179,8 +179,8 @@ class Label(displayio.Group):
     def _get_ascent_descent(self):
         """ Private function to calculate ascent and descent font values """
         if (
-                getattr(self.font, "ascent") is not None and
-                getattr(self.font, "descent") is not None
+            getattr(self.font, "ascent") is not None
+            and getattr(self.font, "descent") is not None
         ):
             return self.font.ascent, self.font.descent
 


### PR DESCRIPTION
With recent changes to bitmapt_font we started using ascent and descent values from the font if they exist. At the time wasn't sure of a font that didn't have those options and it didn't occur to me that I could delete them easily for testing.

This is a modified version of the font with ascent and descent removed. [LeagueSpartan-Bold-16_mod.bdf.txt](https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/files/5937770/LeagueSpartan-Bold-16_mod.bdf.txt)

It turns out our check for having those was insufficient in some cases. We were using hasattr but this seems to still return True for fonts without these values, but it's value is `None` which raises an exception when an attempt to divide it is made.

These changes resolve the issue by checking for None in addition to hasattr. So it will correctly try to fallback to measuring them using the chosen characters.

I tested this fix successfully with Blinka_Displayio, and PyPortal and the font linked above.