### PR TITLE
Transfer the scale attribute down to the inner local_group and keep the scale of Label at 1

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -130,8 +130,6 @@ class Label(displayio.Group):
         self._padding_left = padding_left
         self._padding_right = padding_right
 
-        self._scale = scale
-
         if text is not None:
             self._update_text(str(text))
         if (anchored_position is not None) and (anchor_point is not None):
@@ -389,12 +387,11 @@ class Label(displayio.Group):
     @property
     def scale(self):
         """Set the scaling of the label, in integer values"""
-        return self._scale
+        return self.local_group.scale
 
     @scale.setter
     def scale(self, new_scale):
         current_anchored_position = self.anchored_position
-        self._scale = new_scale
         self.local_group.scale = new_scale
         self.anchored_position = current_anchored_position
 

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -435,13 +435,13 @@ class Label(displayio.Group):
         return (
             int(
                 self.x
-                + (self._boundingbox[0] * self._scale)
-                + round(self._anchor_point[0] * self._boundingbox[2] * self._scale)
+                + (self._boundingbox[0] * self.scale)
+                + round(self._anchor_point[0] * self._boundingbox[2] * self.scale)
             ),
             int(
                 self.y
-                + (self._boundingbox[1] * self._scale)
-                + round(self._anchor_point[1] * self._boundingbox[3] * self._scale)
+                + (self._boundingbox[1] * self.scale)
+                + round(self._anchor_point[1] * self._boundingbox[3] * self.scale)
             ),
         )
 
@@ -451,11 +451,11 @@ class Label(displayio.Group):
             return  # Note: anchor_point must be set before setting anchored_position
         self.x = int(
             new_position[0]
-            - (self._boundingbox[0] * self._scale)
-            - round(self._anchor_point[0] * (self._boundingbox[2] * self._scale))
+            - (self._boundingbox[0] * self.scale)
+            - round(self._anchor_point[0] * (self._boundingbox[2] * self.scale))
         )
         self.y = int(
             new_position[1]
-            - (self._boundingbox[1] * self._scale)
-            - round(self._anchor_point[1] * self._boundingbox[3] * self._scale)
+            - (self._boundingbox[1] * self.scale)
+            - round(self._anchor_point[1] * self._boundingbox[3] * self.scale)
         )


### PR DESCRIPTION
This is a fix for adafruit/Adafruit_CircuitPython_Display_Text#113 .

It keeps the scale of this outer Label at 1 and passes any scale setting
through to the local_group inside as described in the comments already in
the __init__ method.