### PR TITLE
Update scale to remove self._scale that conflicts with Blinka

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -563,12 +563,11 @@ class Label(displayio.Group):
     @property
     def scale(self):
         """Set the scaling of the label, in integer values"""
-        return self._scale
+        return self.local_group.scale
 
     @scale.setter
     def scale(self, new_scale):
         self.local_group.scale = new_scale
-        self._scale = new_scale
         self.anchored_position = self._anchored_position  # update the anchored_position
 
     @property
@@ -580,7 +579,7 @@ class Label(displayio.Group):
     @line_spacing.setter
     def line_spacing(self, new_line_spacing):
         if self._save_text:
-            self._reset_text(line_spacing=new_line_spacing)
+            self._reset_text(line_spacing=new_line_spacing, scale=self.scale)
         else:
             raise RuntimeError("line_spacing is immutable when save_text is False")
 
@@ -621,7 +620,7 @@ class Label(displayio.Group):
 
     @text.setter  # Cannot set color or background color with text setter, use separate setter
     def text(self, new_text):
-        self._reset_text(text=new_text)
+        self._reset_text(text=new_text, scale=self.scale)
 
     @property
     def font(self):
@@ -632,7 +631,7 @@ class Label(displayio.Group):
     def font(self, new_font):
         self._font = new_font
         if self._save_text:
-            self._reset_text(font=new_font)
+            self._reset_text(font=new_font, scale=self.scale)
         else:
             raise RuntimeError("font is immutable when save_text is False")
 


### PR DESCRIPTION
Removing usage of `self._scale` in bitmap_label that is causing conflict with Blinka displayio.Group library's internal variable with the same name.  

I verified the code on a PyPortal and also on Blinka.

This is targeted to resolve this issue on Adafruit_Blinka_Displayio https://github.com/adafruit/Adafruit_Blinka_Displayio/issues/45.

Blinka: Currently released version
<img width="321" alt="image" src="https://user-images.githubusercontent.com/33587466/107387279-47714900-6aba-11eb-9419-1c4a3ac546fc.png">


Blinka: Version with this PR
<img width="320" alt="image" src="https://user-images.githubusercontent.com/33587466/107387071-155fe700-6aba-11eb-954f-c0a1c2c7b2e5.png">


Test code with Blinka and `pygamedisplay`:
```python
import sys

sys.path.append("./lib")


import displayio
import time
import random
import terminalio
from adafruit_blinka import board
from blinka_displayio_pygamedisplay import PyGameDisplay

# The key here is "auto_refresh=False". Failing to do so will create a new thread
# for the rendering, and macOS (or the Python implementation for it) can only be
# performed on the main (UI) thread.
display = PyGameDisplay(width=320, height=240, auto_refresh=False)


# This is a trial of the switch_round_horizontal
# for use on the PyPortal
#
#from adafruit_display_text import label
from adafruit_display_text import bitmap_label as label

# Make the display context
splash = displayio.Group(max_size=10)
display.show(splash)

WIDTH = 320
HEIGHT = 240

# Draw a black background
bg_bitmap = displayio.Bitmap(WIDTH, HEIGHT , 1)
bg_palette = displayio.Palette(1)
bg_palette[0] = 0x000000
splash.append(displayio.TileGrid(bg_bitmap, pixel_shader=bg_palette))

test_label1 = label.Label(terminalio.FONT, text="Scale", scale=1, color=0xFFFFFF, x=8, y=8)
print("Test1 : before append to splash")
print(f"  Scale {test_label1.scale}")
splash.append(test_label1)
print("Test1 : after append to splash")
print(f"  Scale {test_label1.scale}")
print("test_label1.bounding_box: {}".format(test_label1.bounding_box))

print()
test_label2 = label.Label(terminalio.FONT, text="Scale", scale=2, color=0xFFFFFF, x=8, y=38)
print("Test2 : before append to splash")
print(f"  Scale {test_label2.scale}")
splash.append(test_label2)
print("Test2 : after append to splash")
print(f"  Scale {test_label2.scale}")
print("test_label2.bounding_box: {}".format(test_label2.bounding_box))

print()
test_label3 = label.Label(terminalio.FONT, text="Scale", scale=3, color=0xFFFFFF, x=8, y=88)
print("Test3 : before append to splash")
print(f"  Scale {test_label3.scale}")
splash.append(test_label3)
print("Test3 : after append to splash")
print(f"  Scale {test_label3.scale}")
print("test_label3.bounding_box: {}".format(test_label3.bounding_box))

while display.running:
    display.refresh()
```

