### PR TITLE
fix typo in example comment

### DIFF
--- a/examples/display_text_background_color.py
+++ b/examples/display_text_background_color.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-This examples shows the use color and background_color
+This example shows the use color and background_color
 """
 import time
 import board

--- a/examples/display_text_background_color_padding.py
+++ b/examples/display_text_background_color_padding.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-This examples shows the use color and background_color
+This example shows the use color and background_color
 """
 import time
 import board


### PR DESCRIPTION
Found some typos to fix. But mostly hoping this small change will allow the next release to make it to PyPi correctly. It seems when I made the most recent release I mistyped the tag number too low, which caused that upload to PyPi not to work right. 

I tried making a new release with no change, but it seemed to be "stuck" trying to make files containing the previous incorrect version number. Here is the actions results of that attempt: https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/runs/1893413227?check_suite_focus=true