### PR TITLE
Changing logic to include tab replacement and glyph calculation

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -121,7 +121,7 @@ class Label(displayio.Group):
         )  # the local_group will always stay in the self Group
 
         self._font = font
-        self._text = text
+        self._text = "    ".join(text.split("\t"))
 
         # Create the two-color palette
         self.palette = displayio.Palette(2)
@@ -204,7 +204,7 @@ class Label(displayio.Group):
             text = self._text
 
         if self._save_text:  # text string will be saved
-            self._text = text
+            self._text = "    ".join(text.split("\t"))
         else:
             self._text = None  # save a None value since text string is not saved
 
@@ -239,7 +239,7 @@ class Label(displayio.Group):
                 loose_box_y,
                 loose_y_offset,
             ) = self._text_bounding_box(
-                text,
+                self._text,
                 self._font,
                 self._line_spacing,
             )  # calculate the box size for a tight and loose backgrounds
@@ -262,7 +262,7 @@ class Label(displayio.Group):
             # Place the text into the Bitmap
             self._place_text(
                 self.bitmap,
-                text,
+                self._text,
                 self._font,
                 self._line_spacing,
                 self._padding_left - x_offset,
@@ -632,6 +632,7 @@ class Label(displayio.Group):
 
     @text.setter  # Cannot set color or background color with text setter, use separate setter
     def text(self, new_text):
+        new_text = "    ".join(new_text.split("\t"))
         self._reset_text(text=new_text, scale=self.scale)
 
     @property

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -68,7 +68,9 @@ class Label(displayio.Group):
     :param bool save_text: Set True to save the text string as a constant in the
      label structure.  Set False to reduce memory use.
     :param: bool base_alignment: when True allows to align text label to the baseline.
-     This is helpful when two or more labels need to be aligned to the same baseline"""
+     This is helpful when two or more labels need to be aligned to the same baseline
+    :param tuple(int, str): tuple with tab character replace information. When (4, " ")
+     will indicate a tab replacement of 4 spaces, defaults to 4 spaces by tab character"""
 
     # pylint: disable=unused-argument, too-many-instance-attributes, too-many-locals, too-many-arguments
     # pylint: disable=too-many-branches, no-self-use, too-many-statements
@@ -96,6 +98,7 @@ class Label(displayio.Group):
         save_text=True,  # can reduce memory use if save_text = False
         scale=1,
         base_alignment=False,
+        tab_replacement=(4, " "),
         **kwargs,
     ):
 
@@ -121,7 +124,8 @@ class Label(displayio.Group):
         )  # the local_group will always stay in the self Group
 
         self._font = font
-        self._text = "    ".join(text.split("\t"))
+        self.tab_text = tab_replacement[1] * tab_replacement[0]
+        self._text = self.tab_text.join(text.split("\t"))
 
         # Create the two-color palette
         self.palette = displayio.Palette(2)
@@ -150,6 +154,7 @@ class Label(displayio.Group):
             save_text=save_text,
             scale=scale,
             base_alignment=base_alignment,
+            tab_replacement=tab_replacement,
         )
 
     def _reset_text(
@@ -169,6 +174,7 @@ class Label(displayio.Group):
         save_text=None,
         scale=None,
         base_alignment=None,
+        tab_replacement=None,
     ):
 
         # Store all the instance variables
@@ -198,13 +204,14 @@ class Label(displayio.Group):
             self._save_text = save_text
         if base_alignment is not None:
             self.base_alignment = base_alignment
-
+        if tab_replacement is not None:
+            self.tab_replacement = tab_replacement
         # if text is not provided as a parameter (text is None), use the previous value.
         if (text is None) and self._save_text:
             text = self._text
 
         if self._save_text:  # text string will be saved
-            self._text = "    ".join(text.split("\t"))
+            self._text = self.tab_text.join(text.split("\t"))
         else:
             self._text = None  # save a None value since text string is not saved
 
@@ -632,7 +639,7 @@ class Label(displayio.Group):
 
     @text.setter  # Cannot set color or background color with text setter, use separate setter
     def text(self, new_text):
-        new_text = "    ".join(new_text.split("\t"))
+        new_text = self.tab_text.join(new_text.split("\t"))
         self._reset_text(text=new_text, scale=self.scale)
 
     @property

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -91,6 +91,7 @@ class Label(displayio.Group):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
         if not max_glyphs:
+            text = "    ".join(text.split("\t"))
             max_glyphs = len(text)
         # add one to max_size for the background bitmap tileGrid
 

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -61,7 +61,9 @@ class Label(displayio.Group):
      containing x,y pixel coordinates.
     :param int scale: Integer value of the pixel scaling
     :param bool base_alignment: when True allows to align text label to the baseline.
-     This is helpful when two or more labels need to be aligned to the same baseline"""
+     This is helpful when two or more labels need to be aligned to the same baseline
+    :param tuple(int, str): tuple with tab character replace information. When (4, " ")
+     will indicate a tab replacement of 4 spaces, defaults to 4 spaces by tab character"""
 
     # pylint: disable=too-many-instance-attributes, too-many-locals
     # This has a lot of getters/setters, maybe it needs cleanup.
@@ -86,11 +88,13 @@ class Label(displayio.Group):
         anchored_position=None,
         scale=1,
         base_alignment=False,
+        tab_replacement=(4, " "),
         **kwargs
     ):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
-        text = "    ".join(text.split("\t"))
+        self.tab_text = tab_replacement[1] * tab_replacement[0]
+        text = self.tab_text.join(text.split("\t"))
         if not max_glyphs:
             max_glyphs = len(text)
 
@@ -387,7 +391,7 @@ class Label(displayio.Group):
 
     @text.setter
     def text(self, new_text):
-        new_text = "    ".join(new_text.split("\t"))
+        new_text = self.tab_text.join(new_text.split("\t"))
         try:
             current_anchored_position = self.anchored_position
             self._update_text(str(new_text))

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -93,6 +93,7 @@ class Label(displayio.Group):
         if not max_glyphs:
             text = "    ".join(text.split("\t"))
             max_glyphs = len(text)
+        text = "    ".join(text.split("\t"))
         # add one to max_size for the background bitmap tileGrid
 
         # instance the Group

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -90,10 +90,10 @@ class Label(displayio.Group):
     ):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
-        if not max_glyphs:
-            text = "    ".join(text.split("\t"))
-            max_glyphs = len(text)
         text = "    ".join(text.split("\t"))
+        if not max_glyphs:
+            max_glyphs = len(text)
+
         # add one to max_size for the background bitmap tileGrid
 
         # instance the Group

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -95,7 +95,6 @@ class Label(displayio.Group):
             max_glyphs = len(text)
 
         # add one to max_size for the background bitmap tileGrid
-
         # instance the Group
         # self Group will contain a single local_group which contains a Group (self.local_group)
         # which contains a TileGrid

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -387,6 +387,7 @@ class Label(displayio.Group):
 
     @text.setter
     def text(self, new_text):
+        new_text = "    ".join(new_text.split("\t"))
         try:
             current_anchored_position = self.anchored_position
             self._update_text(str(new_text))


### PR DESCRIPTION
Present changes allows the library to change the "\t" tabs by 4 spaces. The library then will use all the normal logic to take care of these. Present solution was chosen for two main reasons:

1. This could be done by a re expression in the form of 
```
if re.search('\t',  text):
    text = text.replace('\t', '    ')
```
However this will imply import the re library. Not sure that this is what why want.
2. We could use a Post treatment using glyph.shift_x in the _update_text module
```
 if not glyph:
    if character == 't':
        glyph = self._font.get_glyph(ord(" "))
        glyph.shift_x = glyph.shift_x * 4
else:
    continue
```
At the end,  we need to return the parameter to the original value with. This needs to be done as the library uses glyph<s parameters for calculations and display:
```
if character == '\t':
    glyph.shift_x = glyph.shift_x // 4
```
This is a hack to disguise a tab as an space with a different shift_x parameter as "\t" will not be found as a glyph. So less Pythonic.

This was tested with the following code:
```
# SPDX-FileCopyrightText: 2021 Jose David Montoya
# SPDX-License-Identifier: MIT

"""
This example shows the changes to verify the tab.
"""

from blinka_displayio_pygamedisplay import PyGameDisplay
import displayio
from adafruit_bitmap_font import bitmap_font
import terminalio
from adafruit_display_text import label

display = PyGameDisplay(width=320, height=240)


# Test parameters
TEXT_BACKGROUND_COLOR = [0xe0433, 0x990099, 0xd6d714, 0xd73014, 0x1415d7, 0x71646f]
TEXT_COLOR = 0x00FF00
FONT_TESTS = [bitmap_font.load_font("IBMPlexMono-Medium-24_jep.bdf"),
              bitmap_font.load_font("LeagueSpartan-Bold-16.bdf"),
              terminalio.FONT]

main_group = displayio.Group(max_size=8)
text = ["\tñ    \t Mp", "    ñ\tp     M", "\tp Mñ\t    ", " tab\ttest "]
ypos = [100, 130, 160, 190]
text_testing = list()
[text_testing.append(label.Label(FONT_TESTS[0],
                                 text=text_iter,
                                 background_color=TEXT_BACKGROUND_COLOR[1],
                                 x=40, y=y_iter))
                                 for text_iter, y_iter in zip(text, ypos)]

[main_group.append(_) for _ in text_testing]

display.show(main_group)

while True:
    pass
```

This produce the following result
![image](https://user-images.githubusercontent.com/34255413/108582350-acba0b00-7300-11eb-85be-93dfef45af47.png)
