### PR TITLE
Vertical label Proposal

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -91,6 +91,7 @@ class Label(displayio.Group):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
         if not max_glyphs:
+            text = "    ".join(text.split("\t"))
             max_glyphs = len(text)
         # add one to max_size for the background bitmap tileGrid
 

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -387,6 +387,7 @@ class Label(displayio.Group):
 
     @text.setter
     def text(self, new_text):
+        "    ".join(new_text.split("\t"))
         try:
             current_anchored_position = self.anchored_position
             self._update_text(str(new_text))

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -93,6 +93,7 @@ class Label(displayio.Group):
         if not max_glyphs:
             text = "    ".join(text.split("\t"))
             max_glyphs = len(text)
+        text = "    ".join(text.split("\t"))
         # add one to max_size for the background bitmap tileGrid
 
         # instance the Group

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -90,10 +90,10 @@ class Label(displayio.Group):
     ):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
-        if not max_glyphs:
-            text = "    ".join(text.split("\t"))
-            max_glyphs = len(text)
         text = "    ".join(text.split("\t"))
+        if not max_glyphs:
+            max_glyphs = len(text)
+
         # add one to max_size for the background bitmap tileGrid
 
         # instance the Group

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -95,7 +95,6 @@ class Label(displayio.Group):
             max_glyphs = len(text)
 
         # add one to max_size for the background bitmap tileGrid
-
         # instance the Group
         # self Group will contain a single local_group which contains a Group (self.local_group)
         # which contains a TileGrid

--- a/adafruit_display_text/vertical_label.py
+++ b/adafruit_display_text/vertical_label.py
@@ -40,11 +40,20 @@ class Label(displayio.Group):
     :param int max_glyphs: The largest quantity of glyphs we will display
     :param int color: Color of all text in RGB hex
     :param float line_spacing: Line spacing of text to display
-    :param bool background_tight: To be implemented
-    :param int padding_top: To be implemented
-    :param int padding_bottom: To be implemented
-    :param int padding_left: To be implemented
-    :param int padding_right: To be implemented.
+    :param bool background_tight: Set `True` only if you want background box to tightly
+     surround text. When set to 'True' Padding parameters will be ignored.
+    :param int padding_top: Additional pixels added to background bounding box at top.
+     This parameter could be negative indicating additional pixels subtracted to background
+     bounding box.
+    :param int padding_bottom: Additional pixels added to background bounding box at bottom.
+     This parameter could be negative indicating additional pixels subtracted to background
+     bounding box.
+    :param int padding_left: Additional pixels added to background bounding box at left.
+     This parameter could be negative indicating additional pixels subtracted to background
+     bounding box.
+    :param int padding_right: Additional pixels added to background bounding box at right.
+     This parameter could be negative indicating additional pixels subtracted to background
+     bounding box.
     :param (float,float) anchor_point: To be implemented
     :param int scale: To be implemented
     :param bool base_alignment: To be implemented"""
@@ -53,26 +62,27 @@ class Label(displayio.Group):
     # This has a lot of getters/setters, maybe it needs cleanup.
 
     def __init__(
-        self,
-        font,
-        *,
-        x=0,
-        y=0,
-        text="",
-        max_glyphs=None,
-        color=0xFFFFFF,
-        background_color=None,
-        line_spacing=1.25,
-        background_tight=False,
-        padding_top=0,
-        padding_bottom=0,
-        padding_left=0,
-        padding_right=0,
-        anchor_point=None,
-        anchored_position=None,
-        scale=1,
-        base_alignment=False,
-        **kwargs
+            self,
+            font,
+            *,
+            x=0,
+            y=0,
+            text="",
+            max_glyphs=None,
+            color=0xFFFFFF,
+            background_color=None,
+            line_spacing=1.25,
+            background_tight=False,
+            padding_top=0,
+            padding_bottom=0,
+            padding_left=0,
+            padding_right=0,
+            anchor_point=None,
+            anchored_position=None,
+            scale=1,
+            base_alignment=False,
+            glyp_para=True,
+            **kwargs
     ):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
@@ -121,6 +131,7 @@ class Label(displayio.Group):
         self._padding_left = padding_left
         self._padding_right = padding_right
         self.base_alignment = base_alignment
+        self.glyp_ana = glyp_para
 
         if text is not None:
             self._update_text(str(text))
@@ -132,28 +143,25 @@ class Label(displayio.Group):
         :param lines: int number of lines
         :param y_offset: int y pixel bottom coordinate for the background_box"""
 
-        # TODO Review all this logic
-        # bottom = self._boundingbox[0]
-
         if self._background_tight:  # draw a tight bounding box
             box_width = self._boundingbox[2]
             box_height = self._boundingbox[3]
-            x_box_offset = self._boundingbox[1]
+            x_box_offset = 0
             y_box_offset = self._boundingbox[0]
 
         else:  # draw a "loose" bounding box to include any ascenders/descenders.
+
             ascent, descent = self._get_ascent_descent()
 
-            box_height = self._boundingbox[3] + self._padding_left + self._padding_right
-            # TODO Verify this for all the paddings
-            # x_box_offset = -self._padding_left
-            x_box_offset = self._boundingbox[1]
-            box_width = (
-                (ascent + descent)
+            box_height = self._boundingbox[3] + self._padding_top + self._padding_bottom
+
+            x_box_offset = -self._padding_bottom
+            box_width = ((ascent + descent)
                 + int((lines - 1) * self.width * self._line_spacing)
                 + self._padding_left
                 + self._padding_right
             )
+            #TODO Verify Self Alignment Logic and Anchor point
             if self.base_alignment:
                 y_box_offset = -ascent - self._padding_left
             else:
@@ -163,13 +171,12 @@ class Label(displayio.Group):
         box_height = max(0, box_height)  # remove any negative values
 
         background_bitmap = displayio.Bitmap(box_width, box_height, 1)
-        # print(f"box_width {box_width} box height: {box_height}")
-        # print(f"ybox ofset: {y_box_offset}")
         tile_grid = displayio.TileGrid(
             background_bitmap,
             pixel_shader=self._background_palette,
             x=y_box_offset,
-            y=x_box_offset - box_height,
+            y=-box_height-x_box_offset
+
         )
         return tile_grid
 
@@ -217,13 +224,13 @@ class Label(displayio.Group):
         if not self._added_background_tilegrid:  # no bitmap is in the self Group
             # add bitmap if text is present and bitmap sizes > 0 pixels
             if (
-                (len(self._text) > 0)
+                    (len(self._text) > 0)
                 and (
                     self._boundingbox[2] + self._padding_left + self._padding_right > 0
-                )
+                    )
                 and (
                     self._boundingbox[3] + self._padding_top + self._padding_bottom > 0
-                )
+                    )
             ):
                 # This can be simplified in CP v6.0, when group.append(0) bug is corrected
                 if len(self.local_group) > 0:
@@ -240,10 +247,10 @@ class Label(displayio.Group):
             # update bitmap if text is present and bitmap sizes > 0 pixels
             if (
                 (len(self._text) > 0)
-                and (
+                    and (
                     self._boundingbox[2] + self._padding_left + self._padding_right > 0
                 )
-                and (
+                    and (
                     self._boundingbox[3] + self._padding_top + self._padding_bottom > 0
                 )
             ):
@@ -266,10 +273,9 @@ class Label(displayio.Group):
             x_offset = 0
         else:
             x_offset = self._get_ascent() // 2
-        # print(f"x_offset: {x_offset}")
 
-        right = top = bottom = 0
-        left = None
+        right = top = left = 0
+        bottom = None
 
         for character in new_text:
             if character == "\n":
@@ -281,17 +287,21 @@ class Label(displayio.Group):
                 continue
             top = min(top, x - glyph.shift_x, x - glyph.width - glyph.dx)
 
-            if x == 0:
-                if left is None:
-                    left = glyph.dy + glyph.height
+            if y == 0:
+                if bottom is None:
+                    bottom = -glyph.dy
                 else:
-                    left = min(left, glyph.dy)
-            # TODO: arrange this logic
-            if y == 0:  # first line, find the Ascender height
-                bottom = min(bottom, -glyph.height - glyph.dy + x_offset)
+                    bottom = min(-bottom, -glyph.dy)
 
+            if x == 0:
+                left = min(left, - glyph.height - glyph.dy + x_offset)
+            right = max(right, x + glyph.dy + x_offset)
             position_x = y - glyph.height - glyph.dy + x_offset
-            position_y = x - glyph.shift_x
+
+            if self.glyp_ana:
+                position_y = x - glyph.shift_x
+            else:
+                position_y = x - glyph.shift_x
 
             if glyph.width > 0 and glyph.height > 0:
                 try:
@@ -322,16 +332,15 @@ class Label(displayio.Group):
                     self.local_group.append(face)
                 tilegrid_count += 1
             x = x - glyph.shift_x
-            i += 1
+            i = i + 1
 
         if left is None:
             left = 0
 
-        while len(self.local_group) > tilegrid_count:  # i:
+        while len(self.local_group) > tilegrid_count:
             self.local_group.pop()
         self._text = new_text
-        # print(f"bounding Box Top: {top} Bot: {bottom} Right: {right} Left: {left}")
-        self._boundingbox = (bottom, right, left, -top)
+        self._boundingbox = (left, bottom, -left+right, -top)
 
         if self.background_color is not None:
             self._update_background_color(self._background_color)

--- a/adafruit_display_text/vertical_label.py
+++ b/adafruit_display_text/vertical_label.py
@@ -1,0 +1,468 @@
+# SPDX-FileCopyrightText: 2021 Jose David Montoya
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_display_text.label`
+====================================================
+
+Displays text labels using CircuitPython's displayio.
+
+* Author(s): Jose David Montoya
+
+Implementation Notes
+--------------------
+
+**Hardware:**
+
+**Software and Dependencies:**
+
+* Adafruit CircuitPython firmware for the supported boards:
+  https://github.com/adafruit/circuitpython/releases
+
+"""
+
+import displayio
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
+
+
+class Label(displayio.Group):
+    """A vertical label displaying a string of text. The origin point set by ``x`` and ``y``
+    properties will be the left edge of the bounding box, and in the center of a M
+    glyph (if its one line), or the (number of lines * linespacing + M)/2. That is,
+    it will try to have it be center-left as close as possible.
+
+    :param Font font: A font class that has ``get_bounding_box`` and ``get_glyph``.
+      Must include a capital M for measuring character size.
+    :param str text: Text to display
+    :param int max_glyphs: The largest quantity of glyphs we will display
+    :param int color: Color of all text in RGB hex
+    :param float line_spacing: Line spacing of text to display
+    :param bool background_tight: To be implemented
+    :param int padding_top: To be implemented
+    :param int padding_bottom: To be implemented
+    :param int padding_left: To be implemented
+    :param int padding_right: To be implemented.
+    :param (float,float) anchor_point: To be implemented
+    :param int scale: To be implemented
+    :param bool base_alignment: To be implemented"""
+
+    # pylint: disable=too-many-instance-attributes, too-many-locals
+    # This has a lot of getters/setters, maybe it needs cleanup.
+
+    def __init__(
+        self,
+        font,
+        *,
+        x=0,
+        y=0,
+        text="",
+        max_glyphs=None,
+        color=0xFFFFFF,
+        background_color=None,
+        line_spacing=1.25,
+        background_tight=False,
+        padding_top=0,
+        padding_bottom=0,
+        padding_left=0,
+        padding_right=0,
+        anchor_point=None,
+        anchored_position=None,
+        scale=1,
+        base_alignment=False,
+        **kwargs
+    ):
+        if not max_glyphs and not text:
+            raise RuntimeError("Please provide a max size, or initial text")
+        text = "    ".join(text.split("\t"))
+        if not max_glyphs:
+            max_glyphs = len(text)
+
+        # add one to max_size for the background bitmap tileGrid
+        # instance the Group
+        # self Group will contain a single local_group which contains a Group (self.local_group)
+        # which contains a TileGrid
+        # The self scale should always be 1
+        super().__init__(max_size=1, scale=1, **kwargs)
+        # local_group will set the scale
+        self.local_group = displayio.Group(max_size=max_glyphs + 1, scale=scale)
+        self.append(self.local_group)
+
+        self.width = max_glyphs
+        self._font = font
+        self._text = None
+        self._anchor_point = anchor_point
+
+        self.x = x
+        self.y = y
+
+        self.height = self._font.get_bounding_box()[1]
+        self._line_spacing = line_spacing
+        self._boundingbox = None
+
+        self._background_tight = (
+            background_tight  # sets padding status for text background box
+        )
+
+        # Create the two-color text palette
+        self.palette = displayio.Palette(2)
+        self.palette[0] = 0
+        self.palette.make_transparent(0)
+        self.color = color
+
+        self._background_color = background_color
+        self._background_palette = displayio.Palette(1)
+        self._added_background_tilegrid = False
+
+        self._padding_top = padding_top
+        self._padding_bottom = padding_bottom
+        self._padding_left = padding_left
+        self._padding_right = padding_right
+        self.base_alignment = base_alignment
+
+        if text is not None:
+            self._update_text(str(text))
+        if (anchored_position is not None) and (anchor_point is not None):
+            self.anchored_position = anchored_position
+
+    def _create_background_box(self, lines, y_offset):
+        """Private Class function to create a background_box
+        :param lines: int number of lines
+        :param y_offset: int y pixel bottom coordinate for the background_box"""
+
+        # TODO Review all this logic
+        # bottom = self._boundingbox[0]
+
+        if self._background_tight:  # draw a tight bounding box
+            box_width = self._boundingbox[2]
+            box_height = self._boundingbox[3]
+            x_box_offset = self._boundingbox[1]
+            y_box_offset = self._boundingbox[0]
+
+        else:  # draw a "loose" bounding box to include any ascenders/descenders.
+            ascent, descent = self._get_ascent_descent()
+
+            box_height = self._boundingbox[3] + self._padding_left + self._padding_right
+            # TODO Verify this for all the paddings
+            # x_box_offset = -self._padding_left
+            x_box_offset = self._boundingbox[1]
+            box_width = (
+                (ascent + descent)
+                + int((lines - 1) * self.width * self._line_spacing)
+                + self._padding_left
+                + self._padding_right
+            )
+            if self.base_alignment:
+                y_box_offset = -ascent - self._padding_left
+            else:
+                y_box_offset = -ascent + y_offset - self._padding_left
+
+        box_width = max(0, box_width)  # remove any negative values
+        box_height = max(0, box_height)  # remove any negative values
+
+        background_bitmap = displayio.Bitmap(box_width, box_height, 1)
+        # print(f"box_width {box_width} box height: {box_height}")
+        # print(f"ybox ofset: {y_box_offset}")
+        tile_grid = displayio.TileGrid(
+            background_bitmap,
+            pixel_shader=self._background_palette,
+            x=y_box_offset,
+            y=x_box_offset - box_height,
+        )
+        return tile_grid
+
+    def _get_ascent_descent(self):
+        """ Private function to calculate ascent and descent font values """
+        if hasattr(self.font, "ascent"):
+            return self.font.ascent, self.font.descent
+
+        # check a few glyphs for maximum ascender and descender height
+        glyphs = "M j'"  # choose glyphs with highest ascender and lowest
+        try:
+            self._font.load_glyphs(glyphs)
+        except AttributeError:
+            # Builtin font doesn't have or need load_glyphs
+            pass
+        # descender, will depend upon font used
+        ascender_max = descender_max = 0
+        for char in glyphs:
+            this_glyph = self._font.get_glyph(ord(char))
+            if this_glyph:
+                ascender_max = max(ascender_max, this_glyph.height + this_glyph.dy)
+                descender_max = max(descender_max, -this_glyph.dy)
+        return ascender_max, descender_max
+
+    def _get_ascent(self):
+        return self._get_ascent_descent()[0]
+
+    def _update_background_color(self, new_color):
+        """Private class function that allows updating the font box background color
+        :param new_color: int color as an RGB hex number."""
+
+        if new_color is None:
+            self._background_palette.make_transparent(0)
+            if self._added_background_tilegrid:
+                self.local_group.pop(0)
+                self._added_background_tilegrid = False
+        else:
+            self._background_palette.make_opaque(0)
+            self._background_palette[0] = new_color
+        self._background_color = new_color
+
+        lines = self._text.rstrip("\n").count("\n") + 1
+        y_offset = self._get_ascent() // 2
+
+        if not self._added_background_tilegrid:  # no bitmap is in the self Group
+            # add bitmap if text is present and bitmap sizes > 0 pixels
+            if (
+                (len(self._text) > 0)
+                and (
+                    self._boundingbox[2] + self._padding_left + self._padding_right > 0
+                )
+                and (
+                    self._boundingbox[3] + self._padding_top + self._padding_bottom > 0
+                )
+            ):
+                # This can be simplified in CP v6.0, when group.append(0) bug is corrected
+                if len(self.local_group) > 0:
+                    self.local_group.insert(
+                        0, self._create_background_box(lines, y_offset)
+                    )
+                else:
+                    self.local_group.append(
+                        self._create_background_box(lines, y_offset)
+                    )
+                self._added_background_tilegrid = True
+
+        else:  # a bitmap is present in the self Group
+            # update bitmap if text is present and bitmap sizes > 0 pixels
+            if (
+                (len(self._text) > 0)
+                and (
+                    self._boundingbox[2] + self._padding_left + self._padding_right > 0
+                )
+                and (
+                    self._boundingbox[3] + self._padding_top + self._padding_bottom > 0
+                )
+            ):
+                self.local_group[0] = self._create_background_box(lines, y_offset)
+            else:  # delete the existing bitmap
+                self.local_group.pop(0)
+                self._added_background_tilegrid = False
+
+    def _update_text(
+        self, new_text
+    ):  # pylint: disable=too-many-locals ,too-many-branches, too-many-statements
+        x = 0
+        y = 0
+        if self._added_background_tilegrid:
+            i = 1
+        else:
+            i = 0
+        tilegrid_count = i
+        if self.base_alignment:
+            x_offset = 0
+        else:
+            x_offset = self._get_ascent() // 2
+        # print(f"x_offset: {x_offset}")
+
+        right = top = bottom = 0
+        left = None
+
+        for character in new_text:
+            if character == "\n":
+                x = x + int(self.height * self._line_spacing)
+                y = 0
+                continue
+            glyph = self._font.get_glyph(ord(character))
+            if not glyph:
+                continue
+            top = min(top, x - glyph.shift_x, x - glyph.width - glyph.dx)
+
+            if x == 0:
+                if left is None:
+                    left = glyph.dy + glyph.height
+                else:
+                    left = min(left, glyph.dy)
+            # TODO: arrange this logic
+            if y == 0:  # first line, find the Ascender height
+                bottom = min(bottom, -glyph.height - glyph.dy + x_offset)
+
+            position_x = y - glyph.height - glyph.dy + x_offset
+            position_y = x - glyph.shift_x
+
+            if glyph.width > 0 and glyph.height > 0:
+                try:
+                    # pylint: disable=unexpected-keyword-arg
+                    face = displayio.TileGrid(
+                        glyph.bitmap,
+                        pixel_shader=self.palette,
+                        default_tile=glyph.tile_index,
+                        tile_width=glyph.width,
+                        tile_height=glyph.height,
+                        position=(position_x, position_y),
+                    )
+                except TypeError:
+                    face = displayio.TileGrid(
+                        glyph.bitmap,
+                        pixel_shader=self.palette,
+                        default_tile=glyph.tile_index,
+                        tile_width=glyph.width,
+                        tile_height=glyph.height,
+                        x=position_x,
+                        y=position_y,
+                    )
+                face.transpose_xy = True
+                face.flip_x = True
+                if tilegrid_count < len(self.local_group):
+                    self.local_group[tilegrid_count] = face
+                else:
+                    self.local_group.append(face)
+                tilegrid_count += 1
+            x = x - glyph.shift_x
+            i += 1
+
+        if left is None:
+            left = 0
+
+        while len(self.local_group) > tilegrid_count:  # i:
+            self.local_group.pop()
+        self._text = new_text
+        # print(f"bounding Box Top: {top} Bot: {bottom} Right: {right} Left: {left}")
+        self._boundingbox = (bottom, right, left, -top)
+
+        if self.background_color is not None:
+            self._update_background_color(self._background_color)
+
+    @property
+    def bounding_box(self):
+        """An (x, y, w, h) tuple that completely covers all glyphs. The
+        first two numbers are offset from the x, y origin of this group"""
+        return tuple(self._boundingbox)
+
+    @property
+    def line_spacing(self):
+        """The amount of space between lines of text, in multiples of the font's
+        bounding-box height. (E.g. 1.0 is the bounding-box height)"""
+        return self._line_spacing
+
+    @line_spacing.setter
+    def line_spacing(self, spacing):
+        self._line_spacing = spacing
+        self.text = self._text  # redraw the box
+
+    @property
+    def color(self):
+        """Color of the text as an RGB hex number."""
+        return self.palette[1]
+
+    @color.setter
+    def color(self, new_color):
+        self._color = new_color
+        if new_color is not None:
+            self.palette[1] = new_color
+            self.palette.make_opaque(1)
+        else:
+            self.palette[1] = 0
+            self.palette.make_transparent(1)
+
+    @property
+    def background_color(self):
+        """Color of the background as an RGB hex number."""
+        return self._background_color
+
+    @background_color.setter
+    def background_color(self, new_color):
+        self._update_background_color(new_color)
+
+    @property
+    def text(self):
+        """Text to display."""
+        return self._text
+
+    @text.setter
+    def text(self, new_text):
+        try:
+            current_anchored_position = self.anchored_position
+            self._update_text(str(new_text))
+            self.anchored_position = current_anchored_position
+        except RuntimeError as run_error:
+            raise RuntimeError("Text length exceeds max_glyphs") from run_error
+
+    @property
+    def scale(self):
+        """Set the scaling of the label, in integer values"""
+        return self.local_group.scale
+
+    @scale.setter
+    def scale(self, new_scale):
+        current_anchored_position = self.anchored_position
+        self.local_group.scale = new_scale
+        self.anchored_position = current_anchored_position
+
+    @property
+    def font(self):
+        """Font to use for text display."""
+        return self._font
+
+    @font.setter
+    def font(self, new_font):
+        old_text = self._text
+        current_anchored_position = self.anchored_position
+        self._text = ""
+        self._font = new_font
+        self.height = self._font.get_bounding_box()[1]
+        self._update_text(str(old_text))
+        self.anchored_position = current_anchored_position
+
+    @property
+    def anchor_point(self):
+        """Point that anchored_position moves relative to.
+        Tuple with decimal percentage of width and height.
+        (E.g. (0,0) is top left, (1.0, 0.5): is middle right.)"""
+        return self._anchor_point
+
+    @anchor_point.setter
+    def anchor_point(self, new_anchor_point):
+        if self._anchor_point is not None:
+            current_anchored_position = self.anchored_position
+            self._anchor_point = new_anchor_point
+            self.anchored_position = current_anchored_position
+        else:
+            self._anchor_point = new_anchor_point
+
+    @property
+    def anchored_position(self):
+        """Position relative to the anchor_point. Tuple containing x,y
+        pixel coordinates."""
+        if self._anchor_point is None:
+            return None
+        return (
+            int(
+                self.x
+                + (self._boundingbox[0] * self.scale)
+                + round(self._anchor_point[0] * self._boundingbox[2] * self.scale)
+            ),
+            int(
+                self.y
+                + (self._boundingbox[1] * self.scale)
+                + round(self._anchor_point[1] * self._boundingbox[3] * self.scale)
+            ),
+        )
+
+    @anchored_position.setter
+    def anchored_position(self, new_position):
+        if (self._anchor_point is None) or (new_position is None):
+            return  # Note: anchor_point must be set before setting anchored_position
+        self.x = int(
+            new_position[0]
+            - (self._boundingbox[0] * self.scale)
+            - round(self._anchor_point[0] * (self._boundingbox[2] * self.scale))
+        )
+        self.y = int(
+            new_position[1]
+            - (self._boundingbox[1] * self.scale)
+            - round(self._anchor_point[1] * self._boundingbox[3] * self.scale)
+        )

--- a/adafruit_display_text/vertical_label.py
+++ b/adafruit_display_text/vertical_label.py
@@ -60,32 +60,33 @@ class Label(displayio.Group):
     :param (int,int) anchored_position: Position relative to the anchor_point. Tuple
      containing x,y pixel coordinates.
     :param int scale: Integer value of the pixel scaling
-    :param bool base_alignment: To be implemented"""
+    :param bool base_alignment: when True allows to align text label to the baseline.
+     This is helpful when two or more labels need to be aligned to the same baseline"""
 
     # pylint: disable=too-many-instance-attributes, too-many-locals
     # This has a lot of getters/setters, maybe it needs cleanup.
 
     def __init__(
-        self,
-        font,
-        *,
-        x=0,
-        y=0,
-        text="",
-        max_glyphs=None,
-        color=0xFFFFFF,
-        background_color=None,
-        line_spacing=1.25,
-        background_tight=False,
-        padding_top=0,
-        padding_bottom=0,
-        padding_left=0,
-        padding_right=0,
-        anchor_point=None,
-        anchored_position=None,
-        scale=1,
-        base_alignment=False,  # TODO add base alignment
-        **kwargs
+            self,
+            font,
+            *,
+            x=0,
+            y=0,
+            text="",
+            max_glyphs=None,
+            color=0xFFFFFF,
+            background_color=None,
+            line_spacing=1.25,
+            background_tight=False,
+            padding_top=0,
+            padding_bottom=0,
+            padding_left=0,
+            padding_right=0,
+            anchor_point=None,
+            anchored_position=None,
+            scale=1,
+            base_alignment=False,
+            **kwargs
     ):
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
@@ -158,8 +159,7 @@ class Label(displayio.Group):
             box_height = self._boundingbox[3] + self._padding_top + self._padding_bottom
 
             x_box_offset = -self._padding_bottom
-            box_width = (
-                (ascent + descent)
+            box_width = ((ascent + descent)
                 + int((lines - 1) * self.width * self._line_spacing)
                 + self._padding_left
                 + self._padding_right
@@ -177,7 +177,8 @@ class Label(displayio.Group):
             background_bitmap,
             pixel_shader=self._background_palette,
             x=y_box_offset,
-            y=-box_height - x_box_offset,
+            y=-box_height-x_box_offset
+
         )
         return tile_grid
 
@@ -225,13 +226,13 @@ class Label(displayio.Group):
         if not self._added_background_tilegrid:  # no bitmap is in the self Group
             # add bitmap if text is present and bitmap sizes > 0 pixels
             if (
-                (len(self._text) > 0)
+                    (len(self._text) > 0)
                 and (
                     self._boundingbox[2] + self._padding_left + self._padding_right > 0
-                )
+                    )
                 and (
                     self._boundingbox[3] + self._padding_top + self._padding_bottom > 0
-                )
+                    )
             ):
                 # This can be simplified in CP v6.0, when group.append(0) bug is corrected
                 if len(self.local_group) > 0:
@@ -248,10 +249,10 @@ class Label(displayio.Group):
             # update bitmap if text is present and bitmap sizes > 0 pixels
             if (
                 (len(self._text) > 0)
-                and (
+                    and (
                     self._boundingbox[2] + self._padding_left + self._padding_right > 0
                 )
-                and (
+                    and (
                     self._boundingbox[3] + self._padding_top + self._padding_bottom > 0
                 )
             ):
@@ -295,10 +296,10 @@ class Label(displayio.Group):
                     bottom = max(bottom, glyph.dx)
 
             if x == 0:
-                left = min(left, -glyph.height - glyph.dy + x_offset)
+                left = min(left, - glyph.height - glyph.dy + x_offset)
             right = max(right, y - glyph.dy + x_offset)
             position_x = y - glyph.height - glyph.dy + x_offset
-            position_y = x - glyph.width - glyph.dx
+            position_y = x - glyph.width- glyph.dx
 
             if glyph.width > 0 and glyph.height > 0:
                 try:
@@ -337,7 +338,7 @@ class Label(displayio.Group):
         while len(self.local_group) > tilegrid_count:
             self.local_group.pop()
         self._text = new_text
-        self._boundingbox = (left, bottom, -left + right, -top)
+        self._boundingbox = (left, bottom, -left+right, -top)
 
         if self.background_color is not None:
             self._update_background_color(self._background_color)


### PR DESCRIPTION
As discussed during the meeting, proposal for vertical label.

Considerations
-It is true that the new architecture will change dramatically display_text, however this improvement could improve the text_label proper.
-A Vertical Progress bar with horizontal text is not very appealing


**This is a Prototype to open the conversation and not a Final Version,**
 and (more or less, a lot of adjusting) the background box is an improvement for the text label

In an interesting topic, you will need to test this in a physical screen, blinka does not work.  I tested the code below in a WIO Terminal using Adafruit CircuitPython 6.1.0

Maybe it could be included in the community bundle. I let you folks decide. (Iy you want my opinion label text should be more open to other languages, where you write from top to bottom, and from left to right) 
@FoamyGuy @jepler @kmatch98 

@jepler reporting that it could be done :). Thanks for the info, and if it was you also for the amazing transpose_xy function 

```
import board
import displayio
from adafruit_bitmap_font import bitmap_font
from adafruit_display_text import label_vertical

display = board.DISPLAY
group = displayio.Group(max_size=12)

text = "CircuitPythoñ"
MEDIUM_FONT = bitmap_font.load_font("/fonts/Helvetica-Bold-16.bdf")

text_area = label_vertical.Label(MEDIUM_FONT, text=text, color=0x00FF00, background_color=0x990099, x=50, y=180)

group.append(text_area)
display.show(group)

while True:
    pass
```

