### PR TITLE
Tab replacement corrections

### DIFF
--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -174,7 +174,10 @@ class LabelBase(Group):
     :param bool save_text: Set True to save the text string as a constant in the
      label structure.  Set False to reduce memory use.
     :param: bool base_alignment: when True allows to align text label to the baseline.
-     This is helpful when two or more labels need to be aligned to the same baseline"""
+     This is helpful when two or more labels need to be aligned to the same baseline
+    :param: (int,str) tab_replacement: tuple with tab character replace information. When
+     (4, " ") will indicate a tab replacement of 4 spaces, defaults to 4 spaces by
+     tab character"""
 
     # pylint: disable=unused-argument,  too-many-instance-attributes, too-many-locals, too-many-arguments
     def __init__(
@@ -198,6 +201,7 @@ class LabelBase(Group):
         save_text=True,  # can reduce memory use if save_text = False
         scale=1,
         base_alignment=False,
+        tab_replacement=(4, " "),
         **kwargs,
     ):
         super().__init__(max_size=1, x=x, y=y, scale=1)

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -70,7 +70,10 @@ class Label(LabelBase):
     :param bool save_text: Set True to save the text string as a constant in the
      label structure.  Set False to reduce memory use.
     :param: bool base_alignment: when True allows to align text label to the baseline.
-     This is helpful when two or more labels need to be aligned to the same baseline"""
+     This is helpful when two or more labels need to be aligned to the same baseline
+    :param: (int,str) tab_replacement: tuple with tab character replace information. When
+     (4, " ") will indicate a tab replacement of 4 spaces, defaults to 4 spaces by
+     tab character"""
 
     # pylint: disable=unused-argument, too-many-instance-attributes, too-many-locals, too-many-arguments
     # pylint: disable=too-many-branches, no-self-use, too-many-statements
@@ -88,7 +91,10 @@ class Label(LabelBase):
             self.local_group
         )  # the local_group will always stay in the self Group
 
-        self._text = kwargs.get("text", "")
+        self.tab_replacement = kwargs.get("tab_replacement", (4, " "))
+        self.tab_text = self.tab_replacement[1] * self.tab_replacement[0]
+        text = kwargs.get("text", "")
+        self._text = self.tab_text.join(text.split("\t"))
 
         # Create the two-color palette
 
@@ -114,6 +120,7 @@ class Label(LabelBase):
             save_text=kwargs.get("save_text", True),
             scale=kwargs.get("scale", 1),
             base_alignment=kwargs.get("base_alignment", False),
+            tab_replacement=kwargs.get("tab_replacement", (4, " ")),
         )
 
     def _reset_text(
@@ -133,6 +140,7 @@ class Label(LabelBase):
         save_text=None,
         scale=None,
         base_alignment=None,
+        tab_replacement=None,
     ):
 
         # Store all the instance variables
@@ -162,13 +170,15 @@ class Label(LabelBase):
             self._save_text = save_text
         if base_alignment is not None:
             self.base_alignment = base_alignment
+        if tab_replacement is not None:
+            self.tab_replacement = tab_replacement
 
         # if text is not provided as a parameter (text is None), use the previous value.
         if (text is None) and self._save_text:
             text = self._text
 
         if self._save_text:  # text string will be saved
-            self._text = text
+            self._text = self.tab_text.join(text.split("\t"))
         else:
             self._text = None  # save a None value since text string is not saved
 
@@ -203,7 +213,7 @@ class Label(LabelBase):
                 loose_box_y,
                 loose_y_offset,
             ) = self._text_bounding_box(
-                text,
+                self._text,
                 self._font,
                 self._line_spacing,
             )  # calculate the box size for a tight and loose backgrounds
@@ -226,7 +236,7 @@ class Label(LabelBase):
             # Place the text into the Bitmap
             self._place_text(
                 self.bitmap,
-                text,
+                self._text,
                 self._font,
                 self._line_spacing,
                 self._padding_left - x_offset,
@@ -542,4 +552,5 @@ class Label(LabelBase):
             raise RuntimeError("font is immutable when save_text is False")
 
     def _set_text(self, new_text, scale):
+        new_text = self.tab_text.join(new_text.split("\t"))
         self._reset_text(text=new_text, scale=self.scale)

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -91,10 +91,10 @@ class Label(LabelBase):
             self.local_group
         )  # the local_group will always stay in the self Group
 
-        self.tab_replacement = kwargs.get("tab_replacement", (4, " "))
-        self.tab_text = self.tab_replacement[1] * self.tab_replacement[0]
+        self._tab_replacement = kwargs.get("tab_replacement", (4, " "))
+        self._tab_text = self._tab_replacement[1] * self._tab_replacement[0]
         text = kwargs.get("text", "")
-        self._text = self.tab_text.join(text.split("\t"))
+        self._text = self._tab_text.join(text.split("\t"))
 
         # Create the two-color palette
 
@@ -171,14 +171,14 @@ class Label(LabelBase):
         if base_alignment is not None:
             self.base_alignment = base_alignment
         if tab_replacement is not None:
-            self.tab_replacement = tab_replacement
+            self._tab_replacement = tab_replacement
 
         # if text is not provided as a parameter (text is None), use the previous value.
         if (text is None) and self._save_text:
             text = self._text
 
         if self._save_text:  # text string will be saved
-            self._text = self.tab_text.join(text.split("\t"))
+            self._text = self._tab_text.join(text.split("\t"))
         else:
             self._text = None  # save a None value since text string is not saved
 
@@ -552,5 +552,5 @@ class Label(LabelBase):
             raise RuntimeError("font is immutable when save_text is False")
 
     def _set_text(self, new_text, scale):
-        new_text = self.tab_text.join(new_text.split("\t"))
+        new_text = self._tab_text.join(new_text.split("\t"))
         self._reset_text(text=new_text, scale=self.scale)

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -63,7 +63,10 @@ class Label(LabelBase):
      containing x,y pixel coordinates.
     :param int scale: Integer value of the pixel scaling
     :param bool base_alignment: when True allows to align text label to the baseline.
-     This is helpful when two or more labels need to be aligned to the same baseline"""
+     This is helpful when two or more labels need to be aligned to the same baseline
+    :param: (int,str) tab_replacement: tuple with tab character replace information. When
+     (4, " ") will indicate a tab replacement of 4 spaces, defaults to 4 spaces by
+     tab character"""
 
     # pylint: disable=too-many-instance-attributes, too-many-locals
     # This has a lot of getters/setters, maybe it needs cleanup.
@@ -76,6 +79,9 @@ class Label(LabelBase):
 
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")
+        self._tab_replacement = kwargs.get("tab_replacement", (4, " "))
+        self._tab_text = self._tab_replacement[1] * self._tab_replacement[0]
+        text = self._tab_text.join(text.split("\t"))
         if not max_glyphs:
             max_glyphs = len(text)
         # add one to max_size for the background bitmap tileGrid
@@ -300,6 +306,7 @@ class Label(LabelBase):
             self._update_background_color(self._background_color)
 
     def _reset_text(self, new_text):
+        new_text = self._tab_text.join(new_text.split("\t"))
         try:
             current_anchored_position = self.anchored_position
             self._update_text(str(new_text))


### PR DESCRIPTION
To replace PR #121. Testing code is the same as used in previous PR

Tested with bitmap_label and label. Similar results as PR #121 showed.  Included corrections from @kmatch98 in that PR.

![image](https://user-images.githubusercontent.com/34255413/110563708-b1145f80-8119-11eb-8e0d-42d3a868bfda.png)

@FoamyGuy as discussed please review.

