### PR TITLE
label.py: Fix Label when initial text is not provided

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -75,7 +75,7 @@ class Label(LabelBase):
         super().__init__(font, **kwargs)
 
         max_glyphs = kwargs.get("max_glyphs", None)
-        text = kwargs.get("text", None)
+        text = kwargs.get("text", "")
 
         if not max_glyphs and not text:
             raise RuntimeError("Please provide a max size, or initial text")


### PR DESCRIPTION
This change addresses cases when Label class is initialized with
max_glyphs instead of text. In such cases, the split function is
attempted on None object instead of an empty string:

  File "/lib/adafruit_display_text/label.py", line 84, in __init__
  AttributeError: 'NoneType' object has no attribute 'split'

Fixes: https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/issues/141