### PR TITLE
Solving kwargs arguments verifications

### DIFF
--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -217,7 +217,7 @@ class LabelBase(Group):
         label_direction: str = "LTR",
         **kwargs,
     ) -> None:
-        super().__init__(max_size=1, x=x, y=y, scale=1)
+        super().__init__(max_size=1, x=x, y=y, scale=1, **kwargs)
 
         self._font = font
         self.palette = Palette(2)


### PR DESCRIPTION
After some verification, I add the ``**kwargs`` arguments to the LabelBase.

This was tested using slightly modified simple test to include and additional argument. will close #146 

## Test Code
```python
import board
import terminalio
from adafruit_display_text import label


text = "Hello world"
text_area = label.Label(terminalio.FONT, text=text, WeTheNorth=True)
text_area.x = 10
text_area.y = 10
board.DISPLAY.show(text_area)
while True:
    pass

```

## Results Original
```python 
Adafruit CircuitPython 6.2.0-beta.4 on 2021-03-18; Seeeduino Wio Terminal with samd51p19
>>> import code
```

## Results After PR
```python
Adafruit CircuitPython 6.2.0-beta.4 on 2021-03-18; Seeeduino Wio Terminal with samd51p19
>>> import code
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "code.py", line 10, in <module>
  File "/lib/adafruit_display_text/label.py", line 78, in __init__
  File "/lib/adafruit_display_text/__init__.py", line 222, in __init__
TypeError: extra keyword arguments given
>>> 
```

