### PR TITLE
correcting_anchor_point for bitmap_label Upwards and Downwards direction

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -299,12 +299,20 @@ class Label(LabelBase):
 
             # Update bounding_box values.  Note: To be consistent with label.py,
             # this is the bounding box for the text only, not including the background.
-            self._bounding_box = (
-                self.tilegrid.x,
-                self.tilegrid.y,
-                box_x,
-                tight_box_y,
-            )
+            if label_direction == "UPR" or self._label_direction == "DWR":
+                self._bounding_box = (
+                    self.tilegrid.x,
+                    self.tilegrid.y,
+                    tight_box_y,
+                    box_x,
+                )
+            else:
+                self._bounding_box = (
+                    self.tilegrid.x,
+                    self.tilegrid.y,
+                    box_x,
+                    tight_box_y,
+                )
 
         if (
             scale is not None


### PR DESCRIPTION
This will correct some small glitches with the anchor point for bitmap_label for the UPR and DWR direction

### Test Code
```python
import displayio
import board
from adafruit_display_text import bitmap_label
from adafruit_bitmap_font import bitmap_font

display = board.DISPLAY

main_group = displayio.Group(max_size=10)
MEDIUM_FONT = bitmap_font.load_font("fonts/Helvetica-Bold-16.bdf")
LINE_HOR = displayio.Bitmap(4, display.height, 2)
LINE_VER = displayio.Bitmap(display.width, 4, 2)
COLOR = 0x990099
palette = displayio.Palette(2)
palette[0] = 0x004400
palette[1] = 0x00FFFF


text_area_UPR = bitmap_label.Label(MEDIUM_FONT,
                                   text="Upwards-1.0",
                                   label_direction="UPR",
                                   background_color=COLOR,
                                   anchored_position=(200, 200),
                                   anchor_point=(1.0, 1.0),
                                    )

text_area_UPR2 = bitmap_label.Label(MEDIUM_FONT,
                                    text="Upwards-0.5",
                                    label_direction="UPR",
                                    background_color=COLOR,
                                    anchored_position=(230, 200),
                                    anchor_point=(1.0, 0.5),
                                    )

text_area_UPR3 = bitmap_label.Label(MEDIUM_FONT,
                                    text="Upwards-0.0", label_direction="UPR",
                                    background_color=COLOR,
                                    anchored_position=(260, 200),
                                    anchor_point=(1.0, 0.0),
                                    )

line_ver = displayio.TileGrid(LINE_VER, pixel_shader=palette, x=0, y=200)
line_hor = displayio.TileGrid(LINE_HOR, pixel_shader=palette, x=200, y=0)
main_group.append(line_ver)
main_group.append(line_hor)

main_group.append(text_area_UPR)
main_group.append(text_area_UPR2)
main_group.append(text_area_UPR3)
display.show(main_group)

while True:
    pass


```