### PR TITLE
Remove max_size parameter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
     hooks:
     -   id: pylint_examples
         name: pylint (examples code)
+        require_serial: true
         description: Run pylint rules on "examples/*.py" files
         entry: /usr/bin/env bash -c
         args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name $example; done)']

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -217,7 +217,7 @@ class LabelBase(Group):
         label_direction: str = "LTR",
         **kwargs,
     ) -> None:
-        super().__init__(max_size=1, x=x, y=y, scale=1, **kwargs)
+        super().__init__(x=x, y=y, scale=1)
 
         self._font = font
         self._ascent, self._descent = self._get_ascent_descent()

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -91,7 +91,7 @@ class Label(LabelBase):
         super().__init__(font, **kwargs)
 
         self.local_group = displayio.Group(
-            max_size=1, scale=kwargs.get("scale", 1)
+            scale=kwargs.get("scale", 1)
         )  # local_group holds the tileGrid and sets the scaling
         self.append(
             self.local_group

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -81,18 +81,15 @@ class Label(LabelBase):
         text = kwargs.get("text", "")
 
         if not max_glyphs and not text:
-            raise RuntimeError("Please provide a max size, or initial text")
+            raise RuntimeError("Please provide a max_glyphs, or initial text")
         self._tab_replacement = kwargs.get("tab_replacement", (4, " "))
         self._tab_text = self._tab_replacement[1] * self._tab_replacement[0]
         text = self._tab_text.join(text.split("\t"))
         if not max_glyphs:
             max_glyphs = len(text)
-        # add one to max_size for the background bitmap tileGrid
 
         # local_group will set the scale
-        self.local_group = displayio.Group(
-            max_size=max_glyphs + 1, scale=kwargs.get("scale", 1)
-        )
+        self.local_group = displayio.Group(scale=kwargs.get("scale", 1))
         self.append(self.local_group)
 
         self.width = max_glyphs

--- a/examples/display_text_advance_example.py
+++ b/examples/display_text_advance_example.py
@@ -15,7 +15,7 @@ from adafruit_display_text import label, bitmap_label
 from adafruit_bitmap_font import bitmap_font
 
 display = board.DISPLAY
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 MEDIUM_FONT = bitmap_font.load_font("fonts/LeagueSpartan-Bold-16.bdf")
 BIG_FONT = bitmap_font.load_font("fonts/LibreBodoniv2002-Bold-27.bdf")
 TIME_PAUSE = 2

--- a/examples/display_text_anchored_position.py
+++ b/examples/display_text_anchored_position.py
@@ -49,7 +49,7 @@ text_area_bottom_right = label.Label(terminalio.FONT, text=TEXT)
 text_area_bottom_right.anchor_point = (1.0, 1.0)
 text_area_bottom_right.anchored_position = (DISPLAY_WIDTH, DISPLAY_HEIGHT)
 
-text_group = displayio.Group(max_size=9)
+text_group = displayio.Group()
 text_group.append(text_area_top_middle)
 text_group.append(text_area_top_left)
 text_group.append(text_area_top_right)

--- a/examples/display_text_background_color_padding.py
+++ b/examples/display_text_background_color_padding.py
@@ -81,7 +81,7 @@ text.append("MONSTERs ate pop quops")  # both ascenders and descenders
 text.append("MONSTER quops\nnewline quops")  # with newline
 
 display.auto_refresh = True
-myGroup = displayio.Group(max_size=6)
+myGroup = displayio.Group()
 display.show(myGroup)
 
 text_area = []

--- a/examples/display_text_label_vs_bitmap_label_comparison.py
+++ b/examples/display_text_label_vs_bitmap_label_comparison.py
@@ -161,7 +161,7 @@ bitmap_label_end = gc.mem_free()
 
 print("bitmap_label used: {} memory".format(bitmap_label_start - bitmap_label_end))
 
-bmap_group = displayio.Group(max_size=4)  # Create a group for displaying
+bmap_group = displayio.Group()  # Create a group for displaying
 bmap_group.append(bmap_label1)
 bmap_group.append(bmap_label2)
 
@@ -209,7 +209,7 @@ gc.collect()
 label_end = gc.mem_free()
 
 print("label used: {} memory".format(label_start - label_end))
-label_group = displayio.Group(max_size=4)  # Create a group for displaying
+label_group = displayio.Group()  # Create a group for displaying
 label_group.append(label1)
 label_group.append(label2)
 

--- a/examples/display_text_pyportal.py
+++ b/examples/display_text_pyportal.py
@@ -27,7 +27,7 @@ for b in range(100):
 
 demos = ["CircuitPython = Code + Community", "accents - üàêùéáçãÍóí", "others - αψ◌"]
 
-splash = displayio.Group(max_size=len(fonts) * len(demos))
+splash = displayio.Group()
 board.DISPLAY.show(splash)
 max_y = 0
 y = 2

--- a/examples/display_text_wrap_pixels_test.py
+++ b/examples/display_text_wrap_pixels_test.py
@@ -24,7 +24,7 @@ text = (
 display = board.DISPLAY
 
 # Make the display context
-main_group = displayio.Group(max_size=10)
+main_group = displayio.Group()
 display.show(main_group)
 
 font = terminalio.FONT


### PR DESCRIPTION
Closes #131

Remove the `max_size` parameter from `Label` and `BitmapLabel` now that it has been disabled in `shared-bindings`.

This has been tested with:
```
Adafruit CircuitPython 6.3.0 on 2021-06-01; Adafruit PyPortal with samd51j20
```