### PR TITLE
bitmap property for bitmap_label

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -39,8 +39,8 @@ from adafruit_display_text import LabelBase
 
 class Label(LabelBase):
     """A label displaying a string of text that is stored in a bitmap.
-    Note: This ``bitmap_label.py`` library utilizes a bitmap to display the text.
-    This method is memory-conserving relative to ``label.py``.
+    Note: This ``bitmap_label.py`` library utilizes a :py:class:`~displayio.Bitmap`
+    to display the text. This method is memory-conserving relative to ``label.py``.
 
     For further reduction in memory usage, set ``save_text=False`` (text string will not
     be stored and ``line_spacing`` and ``font`` are immutable with ``save_text``
@@ -537,5 +537,9 @@ class Label(LabelBase):
 
     @property
     def bitmap(self):
-        """The Bitmap object that the text and background are drawn into."""
+        """
+        The Bitmap object that the text and background are drawn into.
+
+        :rtype: displayio.Bitmap
+        """
         return self._bitmap

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -534,3 +534,8 @@ class Label(LabelBase):
 
     def _get_valid_label_directions(self) -> Tuple[str, ...]:
         return "LTR", "RTL", "UPD", "UPR", "DWR"
+
+    @property
+    def bitmap(self):
+        """The Bitmap object that the text and background are drawn into."""
+        return self._bitmap


### PR DESCRIPTION
Formerly it was possible to access the Bitmap object that is drawn into by BitmapLabel. The [Dial widget makes use of this](https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout/blob/cb263f13f09f3f42cb3183774cbf3bc1c46a4883/adafruit_displayio_layout/widgets/dial.py#L794) in order to apply rotation to labels using `bitmaptools.rotozoom()` 

This PR adds a `bitmap` property for BitmapLabel that restores access to it.
