### PR TITLE
Fix error from save_text = False

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -157,7 +157,7 @@ class Label(LabelBase):
                 loose_box_y,
                 loose_y_offset,
             ) = self._text_bounding_box(
-                self._text,
+                text,
                 self._font,
             )  # calculate the box size for a tight and loose backgrounds
 
@@ -179,7 +179,7 @@ class Label(LabelBase):
             # Place the text into the Bitmap
             self._place_text(
                 self._bitmap,
-                self._text,
+                text,
                 self._font,
                 self._padding_left - x_offset,
                 self._padding_top + y_offset,


### PR DESCRIPTION
This PR should address Issue #157 but I don't have the hardware to test, just followed the code to figure out what was happening.  Use of local variable `text` instead of `self._text` should fix the issue.