### PR TITLE
Resolve missing spaces when long words wrap across a full line.

### DIFF
--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -62,6 +62,7 @@ def wrap_text_to_pixels(
     swidth = measure(" ")
     firstword = True
     for line_in_input in string.split("\n"):
+        newline = True
         for index, word in enumerate(line_in_input.split(" ")):
             wwidth = measure(word)
             word_parts = []
@@ -69,16 +70,28 @@ def wrap_text_to_pixels(
 
             if wwidth > max_width:
                 for char in word:
+                    if newline:
+                        extraspace = 0
+                    else:
+                        extraspace = swidth
                     if (
                         measure("".join(partial))
                         + measure(cur_part)
                         + measure(char)
                         + measure("-")
+                        + extraspace
                         > max_width
                     ):
-                        word_parts.append("".join(partial) + cur_part + "-")
+                        if cur_part:
+                            if newline:
+                                word_parts.append("".join(partial) + cur_part + "-")
+                            else:
+                                word_parts.append("".join(partial) + " " + cur_part + "-")
+                        else:
+                            word_parts.append("".join(partial))
                         cur_part = char
                         partial = [indent1]
+                        newline = True
                     else:
                         cur_part += char
                 if cur_part:
@@ -103,6 +116,8 @@ def wrap_text_to_pixels(
                     lines.append("".join(partial))
                     partial = [indent1, word]
                     width = measure(indent1) + wwidth
+            if newline:
+                newline = False
 
         lines.append("".join(partial))
         partial = [indent1]

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -24,7 +24,7 @@ def wrap_text_to_pixels(
     indent0: str = "",
     indent1: str = "",
 ) -> List[str]:
-    # pylint: disable=too-many-branches, too-many-locals
+    # pylint: disable=too-many-branches, too-many-locals, too-many-nested-blocks, too-many-statements
 
     """wrap_text_to_pixels function
     A helper that will return a list of lines with word-break wrapping.
@@ -86,7 +86,9 @@ def wrap_text_to_pixels(
                             if newline:
                                 word_parts.append("".join(partial) + cur_part + "-")
                             else:
-                                word_parts.append("".join(partial) + " " + cur_part + "-")
+                                word_parts.append(
+                                    "".join(partial) + " " + cur_part + "-"
+                                )
                         else:
                             word_parts.append("".join(partial))
                         cur_part = char

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -72,8 +72,10 @@ def wrap_text_to_pixels(
                 for char in word:
                     if newline:
                         extraspace = 0
+                        leadchar = ""
                     else:
                         extraspace = swidth
+                        leadchar = " "
                     if (
                         measure("".join(partial))
                         + measure(cur_part)
@@ -83,12 +85,10 @@ def wrap_text_to_pixels(
                         > max_width
                     ):
                         if cur_part:
-                            if newline:
-                                word_parts.append("".join(partial) + cur_part + "-")
-                            else:
-                                word_parts.append(
-                                    "".join(partial) + " " + cur_part + "-"
-                                )
+                            word_parts.append(
+                                "".join(partial) + leadchar + cur_part + "-"
+                            )
+
                         else:
                             word_parts.append("".join(partial))
                         cur_part = char


### PR DESCRIPTION
This resolves https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/issues/162

Note: I had to disable "too-many-nested-blocks" to get it to pass pylint.  I agree that the logic is difficult to follow, requiring a refactor of the whole thing to resolve (but I'm passing the technical debt forward for now).

My test code:
```python
import terminalio
from adafruit_display_text import bitmap_label, wrap_text_to_pixels

text_string = "CircuitPython is a programming language designed to simplify experimenting and learning to code on low-cost microcontroller boards."
text_string=text_string+("\n\nWith CircuitPython, there are no upfront desktop downloads needed. Once you get your board set up, open any text editor, and start editing code. It's that simple.")

text_string = "CircuitPython is a programming language designed to simplify experimenting"

for width in range(20, 200, 5):
    text_lines = wrap_text_to_pixels(text_string, width, terminalio.FONT)
    print("width: {}".format(width))
    print('text_lines: {}'.format(text_lines))

while True:
    pass
```


Test result:
```
code.py output:
width: 20
text_lines: ['Ci-', 'rc-', 'ui-', 'tP-', 'yt-', 'ho-', 'n', 'is', 'a', 'pr-', 'og-', 'ra-', 'mm-', 'in-', 'g', 'la-', 'ng-', 'ua-', 'ge', 'de-', 'si-', 'gn-', 'ed', 'to', 'si-', 'mp-', 'li-', 'fy', 'ex-', 'pe-', 'ri-', 'me-', 'nt-', 'in-', 'g']
width: 25
text_lines: ['Cir-', 'cui-', 'tPy-', 'tho-', 'n is', 'a p-', 'rog-', 'ram-', 'min-', 'g l-', 'ang-', 'uag-', 'e d-', 'esi-', 'gne-', 'd to', 'sim-', 'pli-', 'fy', 'exp-', 'eri-', 'men-', 'tin-', 'g']
width: 30
text_lines: ['Circ-', 'uitP-', 'ytho-', 'n is', 'a pr-', 'ogra-', 'mmin-', 'g la-', 'ngua-', 'ge d-', 'esig-', 'ned', 'to s-', 'impl-', 'ify', 'expe-', 'rime-', 'ntin-', 'g']
width: 35
text_lines: ['Circ-', 'uitP-', 'ytho-', 'n is', 'a pr-', 'ogra-', 'mmin-', 'g la-', 'ngua-', 'ge d-', 'esig-', 'ned', 'to s-', 'impl-', 'ify', 'expe-', 'rime-', 'ntin-', 'g']
width: 40
text_lines: ['Circu-', 'itPyt-', 'hon is', 'a pro-', 'gramm-', 'ing l-', 'angua-', 'ge de-', 'signe-', 'd to', 'simpl-', 'ify e-', 'xperi-', 'menti-', 'ng']
width: 45
text_lines: ['Circui-', 'tPytho-', 'n is a', 'progra-', 'mming', 'langua-', 'ge des-', 'igned', 'to sim-', 'plify', 'experi-', 'mentin-', 'g']
width: 50
text_lines: ['Circuit-', 'Python', 'is a pr-', 'ogrammi-', 'ng', 'language', 'designed', 'to', 'simplify', 'experim-', 'enting']
width: 55
text_lines: ['CircuitP-', 'ython is', 'a progra-', 'mming', 'language', 'designed', 'to', 'simplify', 'experime-', 'nting']
width: 60
text_lines: ['CircuitPy-', 'thon is a', 'programmi-', 'ng', 'language', 'designed', 'to', 'simplify', 'experimen-', 'ting']
width: 65
text_lines: ['CircuitPy-', 'thon is a', 'programmi-', 'ng', 'language', 'designed', 'to', 'simplify', 'experimen-', 'ting']
width: 70
text_lines: ['CircuitPyt-', 'hon is a', 'programming', 'language', 'designed to', 'simplify e-', 'xperimenti-', 'ng']
width: 75
text_lines: ['CircuitPyth-', 'on is a', 'programming', 'language', 'designed to', 'simplify ex-', 'perimenting']
width: 80
text_lines: ['CircuitPython', 'is a', 'programming', 'language', 'designed to', 'simplify', 'experimenting']
width: 85
text_lines: ['CircuitPython', 'is a', 'programming', 'language', 'designed to', 'simplify', 'experimenting']
width: 90
text_lines: ['CircuitPython', 'is a', 'programming', 'language', 'designed to', 'simplify', 'experimenting']
width: 95
text_lines: ['CircuitPython', 'is a', 'programming', 'language', 'designed to', 'simplify', 'experimenting']
width: 100
text_lines: ['CircuitPython is', 'a programming', 'language', 'designed to', 'simplify', 'experimenting']
width: 105
text_lines: ['CircuitPython is', 'a programming', 'language designed', 'to simplify', 'experimenting']
width: 110
text_lines: ['CircuitPython is a', 'programming', 'language designed', 'to simplify', 'experimenting']
width: 115
text_lines: ['CircuitPython is a', 'programming', 'language designed', 'to simplify', 'experimenting']
width: 120
text_lines: ['CircuitPython is a', 'programming', 'language designed', 'to simplify', 'experimenting']
width: 125
text_lines: ['CircuitPython is a', 'programming language', 'designed to simplify', 'experimenting']
width: 130
text_lines: ['CircuitPython is a', 'programming language', 'designed to simplify', 'experimenting']
width: 135
text_lines: ['CircuitPython is a', 'programming language', 'designed to simplify', 'experimenting']
width: 140
text_lines: ['CircuitPython is a', 'programming language', 'designed to simplify', 'experimenting']
width: 145
text_lines: ['CircuitPython is a', 'programming language', 'designed to simplify', 'experimenting']
width: 150
text_lines: ['CircuitPython is a', 'programming language', 'designed to simplify', 'experimenting']
width: 155
text_lines: ['CircuitPython is a', 'programming language', 'designed to simplify', 'experimenting']
width: 160
text_lines: ['CircuitPython is a', 'programming language', 'designed to simplify', 'experimenting']
width: 165
text_lines: ['CircuitPython is a', 'programming language', 'designed to simplify', 'experimenting']
width: 170
text_lines: ['CircuitPython is a', 'programming language', 'designed to simplify', 'experimenting']
width: 175
text_lines: ['CircuitPython is a', 'programming language designed', 'to simplify experimenting']
width: 180
text_lines: ['CircuitPython is a', 'programming language designed', 'to simplify experimenting']
width: 185
text_lines: ['CircuitPython is a programming', 'language designed to simplify', 'experimenting']
width: 190
text_lines: ['CircuitPython is a programming', 'language designed to simplify', 'experimenting']
width: 195
text_lines: ['CircuitPython is a programming', 'language designed to simplify', 'experimenting']
```