### PR TITLE
Free the bitmap when set to empty string

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -154,6 +154,10 @@ class Label(LabelBase):
             for _ in self._local_group:
                 self._local_group.pop(0)
 
+            # Free the bitmap and tilegrid since they are removed
+            self._bitmap = None
+            self._tilegrid = None
+
         else:  # The text string is not empty, so create the Bitmap and TileGrid and
             # append to the self Group
 
@@ -200,9 +204,7 @@ class Label(LabelBase):
             # Place the text into the Bitmap
             self._place_text(
                 self._bitmap,
-                text
-                if self._label_direction != "RTL"
-                else "".join(reversed(self._text)),
+                text if self._label_direction != "RTL" else "".join(reversed(text)),
                 self._font,
                 self._padding_left - x_offset,
                 self._padding_top + y_offset,


### PR DESCRIPTION
In the latest release, setting the text to an empty string, then back to a string of the same size as the previous (non-empty) value, the bitmap label would not be updated, remaining invisible until its size changed. [See this code for example](https://github.com/adafruit/Adafruit_CircuitPython_MacroPad/blob/main/examples/macropad_grid_layout.py). This is because `self._bitmap` was still set, with the right size, so was `self._tilegrid`, so `self._local_group` remained empty.

(Also one use of `self._text` instead of `text` fixed).