### PR TITLE
Use `fontio.FontProtocol` for type annotations

### DIFF
--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -7,6 +7,9 @@
 =======================
 """
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
+
 from displayio import Group, Palette
 
 try:

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -7,12 +7,13 @@
 =======================
 """
 
+from displayio import Group, Palette
+
 try:
     from typing import Optional, List, Tuple
     from fontio import FontProtocol
 except ImportError:
     pass
-from displayio import Group, Palette
 
 
 def wrap_text_to_pixels(

--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -8,10 +8,8 @@
 """
 
 try:
-    from typing import Optional, Union, List, Tuple
-    from fontio import BuiltinFont
-    from adafruit_bitmap_font.bdf import BDF
-    from adafruit_bitmap_font.pcf import PCF
+    from typing import Optional, List, Tuple
+    from fontio import FontProtocol
 except ImportError:
     pass
 from displayio import Group, Palette
@@ -20,7 +18,7 @@ from displayio import Group, Palette
 def wrap_text_to_pixels(
     string: str,
     max_width: int,
-    font: Optional[Union[BuiltinFont, BDF, PCF]] = None,
+    font: Optional[FontProtocol] = None,
     indent0: str = "",
     indent1: str = "",
 ) -> List[str]:
@@ -35,7 +33,7 @@ def wrap_text_to_pixels(
     :param str string: The text to be wrapped.
     :param int max_width: The maximum number of pixels on a line before wrapping.
     :param font: The font to use for measuring the text.
-    :type font: ~BuiltinFont, ~BDF, or ~PCF
+    :type font: ~FontProtocol
     :param str indent0: Additional character(s) to add to the first line.
     :param str indent1: Additional character(s) to add to all other lines.
 
@@ -191,7 +189,7 @@ class LabelBase(Group):
 
     :param font: A font class that has ``get_bounding_box`` and ``get_glyph``.
       Must include a capital M for measuring character size.
-    :type font: ~BuiltinFont, ~BDF, or ~PCF
+    :type font: ~FontProtocol
     :param str text: Text to display
     :param int color: Color of all text in RGB hex
     :param int background_color: Color of the background, use `None` for transparent
@@ -218,7 +216,7 @@ class LabelBase(Group):
 
     def __init__(
         self,
-        font: Union[BuiltinFont, BDF, PCF],
+        font: FontProtocol,
         x: int = 0,
         y: int = 0,
         text: str = "",
@@ -304,15 +302,15 @@ class LabelBase(Group):
         return ascender_max, descender_max
 
     @property
-    def font(self) -> Union[BuiltinFont, BDF, PCF]:
+    def font(self) -> FontProtocol:
         """Font to use for text display."""
         return self._font
 
-    def _set_font(self, new_font: Union[BuiltinFont, BDF, PCF]) -> None:
+    def _set_font(self, new_font: FontProtocol) -> None:
         raise NotImplementedError("{} MUST override '_set_font'".format(type(self)))
 
     @font.setter
-    def font(self, new_font: Union[BuiltinFont, BDF, PCF]) -> None:
+    def font(self, new_font: FontProtocol) -> None:
         self._set_font(new_font)
 
     @property

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -28,10 +28,8 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
 
 
 try:
-    from typing import Union, Optional, Tuple
-    from fontio import BuiltinFont
-    from adafruit_bitmap_font.bdf import BDF
-    from adafruit_bitmap_font.pcf import PCF
+    from typing import Optional, Tuple
+    from fontio import FontProtocol
 except ImportError:
     pass
 
@@ -56,7 +54,7 @@ class Label(LabelBase):
 
     :param font: A font class that has ``get_bounding_box`` and ``get_glyph``.
       Must include a capital M for measuring character size.
-    :type font: ~BuiltinFont, ~BDF, or ~PCF
+    :type font: ~FontProtocol
     :param str text: Text to display
     :param int color: Color of all text in RGB hex
     :param int background_color: Color of the background, use `None` for transparent
@@ -93,9 +91,7 @@ class Label(LabelBase):
         "RTL": (False, False, False),
     }
 
-    def __init__(
-        self, font: Union[BuiltinFont, BDF, PCF], save_text: bool = True, **kwargs
-    ) -> None:
+    def __init__(self, font: FontProtocol, save_text: bool = True, **kwargs) -> None:
 
         self._bitmap = None
         self._tilegrid = None
@@ -116,7 +112,7 @@ class Label(LabelBase):
 
     def _reset_text(
         self,
-        font: Optional[Union[BuiltinFont, BDF, PCF]] = None,
+        font: Optional[FontProtocol] = None,
         text: Optional[str] = None,
         line_spacing: Optional[float] = None,
         scale: Optional[int] = None,
@@ -270,15 +266,13 @@ class Label(LabelBase):
         self.anchored_position = self._anchored_position
 
     @staticmethod
-    def _line_spacing_ypixels(
-        font: Union[BuiltinFont, BDF, PCF], line_spacing: float
-    ) -> int:
+    def _line_spacing_ypixels(font: FontProtocol, line_spacing: float) -> int:
         # Note: Scaling is provided at the Group level
         return_value = int(line_spacing * font.get_bounding_box()[1])
         return return_value
 
     def _text_bounding_box(
-        self, text: str, font: Union[BuiltinFont, BDF, PCF]
+        self, text: str, font: FontProtocol
     ) -> Tuple[int, int, int, int, int, int]:
         # pylint: disable=too-many-locals
 
@@ -360,7 +354,7 @@ class Label(LabelBase):
         self,
         bitmap: displayio.Bitmap,
         text: str,
-        font: Union[BuiltinFont, BDF, PCF],
+        font: FontProtocol,
         xposition: int,
         yposition: int,
         skip_index: int = 0,  # set to None to write all pixels, other wise skip this palette index
@@ -534,7 +528,7 @@ class Label(LabelBase):
         else:
             raise RuntimeError("line_spacing is immutable when save_text is False")
 
-    def _set_font(self, new_font: Union[BuiltinFont, BDF, PCF]) -> None:
+    def _set_font(self, new_font: FontProtocol) -> None:
         self._font = new_font
         if self._save_text:
             self._reset_text(font=new_font, scale=self.scale)

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -26,6 +26,8 @@ Implementation Notes
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
 
+import displayio
+from adafruit_display_text import LabelBase
 
 try:
     from typing import Optional, Tuple
@@ -33,9 +35,6 @@ try:
 except ImportError:
     pass
 
-import displayio
-
-from adafruit_display_text import LabelBase
 
 # pylint: disable=too-many-instance-attributes
 class Label(LabelBase):

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -27,10 +27,8 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
 
 
 try:
-    from typing import Union, Optional, Tuple
-    from fontio import BuiltinFont
-    from adafruit_bitmap_font.bdf import BDF
-    from adafruit_bitmap_font.pcf import PCF
+    from typing import Optional, Tuple
+    from fontio import FontProtocol
 except ImportError:
     pass
 
@@ -49,7 +47,7 @@ class Label(LabelBase):
 
     :param font: A font class that has ``get_bounding_box`` and ``get_glyph``.
       Must include a capital M for measuring character size.
-    :type font: ~BuiltinFont, ~BDF, or ~PCF
+    :type font: ~FontProtocol
     :param str text: Text to display
     :param int color: Color of all text in RGB hex
     :param int background_color: Color of the background, use `None` for transparent
@@ -83,7 +81,7 @@ class Label(LabelBase):
      configurations possibles ``LTR``-Left-To-Right ``RTL``-Right-To-Left
      ``TTB``-Top-To-Bottom ``UPR``-Upwards ``DWR``-Downwards. It defaults to ``LTR``"""
 
-    def __init__(self, font: Union[BuiltinFont, BDF, PCF], **kwargs) -> None:
+    def __init__(self, font: FontProtocol, **kwargs) -> None:
         self._background_palette = Palette(1)
         self._added_background_tilegrid = False
 
@@ -403,7 +401,7 @@ class Label(LabelBase):
         self._update_text(str(self._replace_tabs(new_text)))
         self.anchored_position = current_anchored_position
 
-    def _set_font(self, new_font: Union[BuiltinFont, BDF, PCF]) -> None:
+    def _set_font(self, new_font: FontProtocol) -> None:
         old_text = self._text
         current_anchored_position = self.anchored_position
         self._text = ""

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -26,15 +26,14 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
 
 
+from displayio import Bitmap, Palette, TileGrid
+from adafruit_display_text import LabelBase
+
 try:
     from typing import Optional, Tuple
     from fontio import FontProtocol
 except ImportError:
     pass
-
-from displayio import Bitmap, Palette, TileGrid
-
-from adafruit_display_text import LabelBase
 
 
 class Label(LabelBase):

--- a/adafruit_display_text/scrolling_label.py
+++ b/adafruit_display_text/scrolling_label.py
@@ -26,14 +26,14 @@ Implementation Notes
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
 
+import time
+from adafruit_display_text import bitmap_label
+
 try:
     from typing import Optional
     from fontio import FontProtocol
 except ImportError:
     pass
-
-import time
-from adafruit_display_text import bitmap_label
 
 
 class ScrollingLabel(bitmap_label.Label):


### PR DESCRIPTION
Resolves #172 by using `fontio.FontProtocol` for type annotations instead of that huge `Union`.