### PR TITLE
Corrected typing to allow the color arguments to also take a Tuple

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -56,7 +56,7 @@ class Label(LabelBase):
     :type font: ~FontProtocol
     :param str text: Text to display
     :param int|Tuple(int, int, int) color: Color of all text in HEX or RGB
-    :param int|Tuple(int, int, int) background_color: Color of the background, use `None`
+    :param int|Tuple(int, int, int)|None background_color: Color of the background, use `None`
      for transparent
     :param float line_spacing: Line spacing of text to display
     :param bool background_tight: Set `True` only if you want background box to tightly

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -55,8 +55,9 @@ class Label(LabelBase):
       Must include a capital M for measuring character size.
     :type font: ~FontProtocol
     :param str text: Text to display
-    :param int color: Color of all text in RGB hex
-    :param int background_color: Color of the background, use `None` for transparent
+    :param int|Tuple(int, int, int) color: Color of all text in HEX or RGB
+    :param int|Tuple(int, int, int) background_color: Color of the background, use `None`
+     for transparent
     :param float line_spacing: Line spacing of text to display
     :param bool background_tight: Set `True` only if you want background box to tightly
      surround text. When set to 'True' Padding parameters will be ignored.
@@ -64,17 +65,17 @@ class Label(LabelBase):
     :param int padding_bottom: Additional pixels added to background bounding box at bottom
     :param int padding_left: Additional pixels added to background bounding box at left
     :param int padding_right: Additional pixels added to background bounding box at right
-    :param (float,float) anchor_point: Point that anchored_position moves relative to.
+    :param Tuple(float, float) anchor_point: Point that anchored_position moves relative to.
      Tuple with decimal percentage of width and height.
      (E.g. (0,0) is top left, (1.0, 0.5): is middle right.)
-    :param (int,int) anchored_position: Position relative to the anchor_point. Tuple
+    :param Tuple(int, int) anchored_position: Position relative to the anchor_point. Tuple
      containing x,y pixel coordinates.
     :param int scale: Integer value of the pixel scaling
     :param bool save_text: Set True to save the text string as a constant in the
      label structure.  Set False to reduce memory use.
     :param bool base_alignment: when True allows to align text label to the baseline.
      This is helpful when two or more labels need to be aligned to the same baseline
-    :param (int,str) tab_replacement: tuple with tab character replace information. When
+    :param Tuple(int, str) tab_replacement: tuple with tab character replace information. When
      (4, " ") will indicate a tab replacement of 4 spaces, defaults to 4 spaces by
      tab character
     :param str label_direction: string defining the label text orientation. There are 5

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -49,7 +49,7 @@ class Label(LabelBase):
     :type font: ~FontProtocol
     :param str text: Text to display
     :param int|Tuple(int, int, int) color: Color of all text in HEX or RGB
-    :param int|Tuple(int, int, int) background_color: Color of the background, use `None`
+    :param int|Tuple(int, int, int)|None background_color: Color of the background, use `None`
      for transparent
     :param float line_spacing: Line spacing of text to display
     :param bool background_tight: Set `True` only if you want background box to tightly

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -48,8 +48,9 @@ class Label(LabelBase):
       Must include a capital M for measuring character size.
     :type font: ~FontProtocol
     :param str text: Text to display
-    :param int color: Color of all text in RGB hex
-    :param int background_color: Color of the background, use `None` for transparent
+    :param int|Tuple(int, int, int) color: Color of all text in HEX or RGB
+    :param int|Tuple(int, int, int) background_color: Color of the background, use `None`
+     for transparent
     :param float line_spacing: Line spacing of text to display
     :param bool background_tight: Set `True` only if you want background box to tightly
      surround text. When set to 'True' Padding parameters will be ignored.
@@ -65,15 +66,15 @@ class Label(LabelBase):
     :param int padding_right: Additional pixels added to background bounding box at right.
      This parameter could be negative indicating additional pixels subtracted from the
      background bounding box.
-    :param (float,float) anchor_point: Point that anchored_position moves relative to.
+    :param Tuple(float, float) anchor_point: Point that anchored_position moves relative to.
      Tuple with decimal percentage of width and height.
      (E.g. (0,0) is top left, (1.0, 0.5): is middle right.)
-    :param (int,int) anchored_position: Position relative to the anchor_point. Tuple
+    :param Tuple(int, int) anchored_position: Position relative to the anchor_point. Tuple
      containing x,y pixel coordinates.
     :param int scale: Integer value of the pixel scaling
     :param bool base_alignment: when True allows to align text label to the baseline.
      This is helpful when two or more labels need to be aligned to the same baseline
-    :param (int,str) tab_replacement: tuple with tab character replace information. When
+    :param Tuple(int, str) tab_replacement: tuple with tab character replace information. When
      (4, " ") will indicate a tab replacement of 4 spaces, defaults to 4 spaces by
      tab character
     :param str label_direction: string defining the label text orientation. There are 5


### PR DESCRIPTION
Hi,

This PR solves Label can take Tuple[int, int, int] for color #175 

Both parameters, `color` and `backgrount_color` can take either an int or a Tuple[int, int, int].

I tested label and bitmap_label with the Adafruit Feather RP2040 and the ST7789 display.

Please let me know if you have any comments!
Thanks! 