### PR TITLE
Ignore characters that are not printable in wrap_text_to_pixels

### DIFF
--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -56,7 +56,12 @@ def wrap_text_to_pixels(
             font.load_glyphs(string)
 
         def measure(text):
-            return sum(font.get_glyph(ord(c)).shift_x for c in text)
+            total_len = 0
+            for char in text:
+                this_glyph = font.get_glyph(ord(char))
+                if this_glyph:
+                    total_len += this_glyph.shift_x
+            return total_len
 
     lines = []
     partial = [indent0]


### PR DESCRIPTION
Setting a label's text to a string containing unprintable characters doesn't error but has the character ignored.
Calling wrap_text_to_pixels() on the same string however raises an error.

Test code:
```py
import board
import displayio
import terminalio
import time
from adafruit_display_text.label import Label
from adafruit_display_text import wrap_text_to_pixels

# setup the display if not built-in
display = board.DISPLAY

label = Label(x=0, y=20, font=terminalio.FONT, color=0xFFFFFF, scale=4)
display.show(label)

TEST_STRING = "--§§--\r\n--"
label.text = TEST_STRING
time.sleep(1)
out = wrap_text_to_pixels(
    TEST_STRING,
    font=terminalio.FONT,
    max_width=64
)
label.text = "\n".join(out)
while True: pass
```
Before:
```py
Traceback (most recent call last):
  File "code.py", line 19, in <module>
  File "adafruit_display_text/__init__.py", line 69, in wrap_text_to_pixels
  File "adafruit_display_text/__init__.py", line 59, in measure
  File "adafruit_display_text/__init__.py", line 59, in <genexpr>
AttributeError: 'NoneType' object has no attribute 'shift_x'
```
After:

![dashdashdash](https://user-images.githubusercontent.com/6160205/210029381-07cfe63a-3aa3-4cdd-8da7-4a5e79a5a9d3.jpg)

Also fixes #177
