### PR TITLE
fix left edge location for first character of the label.

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -314,7 +314,7 @@ class Label(LabelBase):
                         lines += 1
                     if xposition == x_start:
                         if left is None:
-                            left = my_glyph.dx
+                            left = 0
                         else:
                             left = min(left, my_glyph.dx)
                     xright = xposition + my_glyph.width + my_glyph.dx
@@ -392,7 +392,7 @@ class Label(LabelBase):
                 else:
                     if xposition == x_start:
                         if left is None:
-                            left = my_glyph.dx
+                            left = 0
                         else:
                             left = min(left, my_glyph.dx)
 

--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -271,7 +271,7 @@ class Label(LabelBase):
                     right = max(right, x + glyph.shift_x, x + glyph.width + glyph.dx)
                     if x == 0:
                         if left is None:
-                            left = glyph.dx
+                            left = 0
                         else:
                             left = min(left, glyph.dx)
                     position_x = x + glyph.dx
@@ -281,7 +281,7 @@ class Label(LabelBase):
                     )
                     if x == 0:
                         if right is None:
-                            right = glyph.dx
+                            right = 0
                         else:
                             right = max(right, glyph.dx)
                     position_x = x - glyph.width
@@ -289,7 +289,7 @@ class Label(LabelBase):
             elif self._label_direction == "TTB":
                 if x == 0:
                     if left is None:
-                        left = glyph.dx
+                        left = 0
                     else:
                         left = min(left, glyph.dx)
                 if y == 0:


### PR DESCRIPTION
This fixes an issue that resulted in multiple labels using monospace fonts with different leading characters to not align properly if the shift x values from the bounding box property in the font is different for different characters. 

The change hardcodes the left value to start at 0 rather than the shift x value which was actually causing the shift to get "cut out" and no included in the final bitmap, as well as causing alignment to become misaligned with other labels placed at the same x position.

This problem was original reported on the forums here: https://forums.adafruit.com/viewtopic.php?p=954011

There are details and photos in that forum post. 

Here are some photos illustrating the difference with this proposed change:

Currently released version:
![current_impl](https://user-images.githubusercontent.com/2406189/210151184-49442708-3890-4506-aa1b-794d38c9da47.png)

This PR version:
![pr_version](https://user-images.githubusercontent.com/2406189/210151186-9e992384-c643-46be-84f8-c5cff4951cc8.png)


If adopted this change would result in the visual x location of labels to change slightly depending on the shift x value for the leading character in whatever font is used. Projects that used larger fonts, or fonts with larger shift x values will see a more substantial change.

This change also has the side effect of putting in the left side padding inside the background box of the label. Previously the left edge of the first character was touching the left edge of the label background rectangle, with this version the shift from the font is respected and used as a left padding.
