### PR TITLE
adding_verbose_option

### DIFF
--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -221,7 +221,9 @@ class LabelBase(Group):
      (4, " ") will indicate a tab replacement of 4 spaces, defaults to 4 spaces by
      tab character
     :param str label_direction: string defining the label text orientation. See the
-     subclass documentation for the possible values."""
+     subclass documentation for the possible values.
+    :param bool verbose: print debugging information in some internal functions. Default to False
+    """
 
     def __init__(
         self,
@@ -243,6 +245,7 @@ class LabelBase(Group):
         base_alignment: bool = False,
         tab_replacement: Tuple[int, str] = (4, " "),
         label_direction: str = "LTR",
+        verbose: bool = False,
         **kwargs,  # pylint: disable=unused-argument
     ) -> None:
         # pylint: disable=too-many-arguments, too-many-locals
@@ -266,6 +269,7 @@ class LabelBase(Group):
         self._label_direction = label_direction
         self._tab_replacement = tab_replacement
         self._tab_text = self._tab_replacement[1] * self._tab_replacement[0]
+        self._verbose = verbose
 
         if "max_glyphs" in kwargs:
             print("Please update your code: 'max_glyphs' is not needed anymore.")

--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -80,7 +80,10 @@ class Label(LabelBase):
      tab character
     :param str label_direction: string defining the label text orientation. There are 5
      configurations possibles ``LTR``-Left-To-Right ``RTL``-Right-To-Left
-     ``UPD``-Upside Down ``UPR``-Upwards ``DWR``-Downwards. It defaults to ``LTR``"""
+     ``UPD``-Upside Down ``UPR``-Upwards ``DWR``-Downwards. It defaults to ``LTR``
+     :param bool verbose: print debugging information in some internal functions. Default to False
+
+    """
 
     # This maps label_direction to TileGrid's transpose_xy, flip_x, flip_y
     _DIR_MAP = {
@@ -350,6 +353,7 @@ class Label(LabelBase):
             final_y_offset_loose,
         )
 
+    # pylint: disable = too-many-branches
     def _place_text(
         self,
         bitmap: displayio.Bitmap,
@@ -418,19 +422,20 @@ class Label(LabelBase):
                     if y_blit_target < 0:
                         y_clip = -y_blit_target  # clip this amount from top of bitmap
                         y_blit_target = 0  # draw the clipped bitmap at y=0
-
-                        print(
-                            'Warning: Glyph clipped, exceeds Ascent property: "{}"'.format(
-                                char
+                        if self._verbose:
+                            print(
+                                'Warning: Glyph clipped, exceeds Ascent property: "{}"'.format(
+                                    char
+                                )
                             )
-                        )
 
                     if (y_blit_target + my_glyph.height) > bitmap.height:
-                        print(
-                            'Warning: Glyph clipped, exceeds descent property: "{}"'.format(
-                                char
+                        if self._verbose:
+                            print(
+                                'Warning: Glyph clipped, exceeds descent property: "{}"'.format(
+                                    char
+                                )
                             )
-                        )
 
                     self._blit(
                         bitmap,


### PR DESCRIPTION
Related to #171 


tested with:
```python
import time
import board
import terminalio
import displayio
from adafruit_display_text import bitmap_label

display = board.DISPLAY

main_group = displayio.Group()
MEDIUM_FONT = bitmap_font.load_font("LeagueSpartan-Bold-16.bdf")

TIME_PAUSE = 1

# Testing creating label with initial position
text_area = bitmap_label.Label(terminalio.FONT, x=20, y=20, text="Verbose Option Testing", verbose=True)
main_group.append(text_area)
display.show(main_group)
time.sleep(TIME_PAUSE)

# Testing Verbose
text_area.text = "Testing Verbose=True"
text_initial_specs = bitmap_label.Label(
    MEDIUM_FONT,
    text="Verbose",
    x=display.width // 2,
    y=display.height // 2,
    verbose=True,
)
main_group.append(text_initial_specs)
display.show(main_group)
time.sleep(TIME_PAUSE)
main_group.pop()

text_area.text = "Testing Verbose=False"
print("putting the Verbose=False will no show the warning")
time.sleep(TIME_PAUSE)
text_initial_specs = bitmap_label.Label(
    MEDIUM_FONT,
    text=" Not Verbose",
    x=display.width // 2,
    y=display.height // 2,
    verbose=False,
)
main_group.append(text_initial_specs)
display.show(main_group)
time.sleep(TIME_PAUSE)
main_group.pop()

text_area.text = "Finished"
print("Tests finished")

```