### PR TITLE
Fix the position of bitmap_label with padding and anchored_position

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -81,7 +81,7 @@ class Label(LabelBase):
     :param str label_direction: string defining the label text orientation. There are 5
      configurations possibles ``LTR``-Left-To-Right ``RTL``-Right-To-Left
      ``UPD``-Upside Down ``UPR``-Upwards ``DWR``-Downwards. It defaults to ``LTR``
-     :param bool verbose: print debugging information in some internal functions. Default to False
+    :param bool verbose: print debugging information in some internal functions. Default to False
 
     """
 
@@ -185,6 +185,7 @@ class Label(LabelBase):
                 y_offset = loose_y_offset
 
             # Calculate the background size including padding
+            tight_box_x = box_x
             box_x = box_x + self._padding_left + self._padding_right
             box_y = box_y + self._padding_top + self._padding_bottom
 
@@ -245,17 +246,23 @@ class Label(LabelBase):
             # Update bounding_box values.  Note: To be consistent with label.py,
             # this is the bounding box for the text only, not including the background.
             if self._label_direction in ("UPR", "DWR"):
+                if self._label_direction == "UPR":
+                    top = self._padding_right
+                    left = self._padding_top
+                if self._label_direction == "DWR":
+                    top = self._padding_left
+                    left = self._padding_bottom
                 self._bounding_box = (
-                    self._tilegrid.x,
-                    self._tilegrid.y,
+                    self._tilegrid.x + left,
+                    self._tilegrid.y + top,
                     tight_box_y,
-                    box_x,
+                    tight_box_x,
                 )
             else:
                 self._bounding_box = (
-                    self._tilegrid.x,
-                    self._tilegrid.y,
-                    box_x,
+                    self._tilegrid.x + self._padding_left,
+                    self._tilegrid.y + self._padding_top,
+                    tight_box_x,
                     tight_box_y,
                 )
 


### PR DESCRIPTION
When adding padding to a bitmap label and setting its anchored_position, the location of the label is incorrect.
This fixes the calculation, and makes bitmap labels display the same way as labels when possible.
Note: I assumed that the intention is for the position to be based on the corner of the text, and not the full box.

The first test shows each label.Label in grey (correctly placed), and the bitmap_label.Label in color on top of it.
The other test shows the fixed bitmap_label.Label in green on top of the old one in red.

Before
![bitmap_label-before-pr](https://user-images.githubusercontent.com/6160205/224370901-5e27fd9e-f133-408f-8376-bdc5eeb7321a.jpg)

After
![bitmap_label-after-pr](https://user-images.githubusercontent.com/6160205/224370897-4275c0ef-d69b-483d-af93-3930c5c0f33c.jpg)

Here are DWR and UPR bitmap_label, fixed in green on top of the current ones in red. (No comparison with label.Label because or #185 which should be fixed on its own).

![paddings-bitmap-label-fixed-unfixed](https://user-images.githubusercontent.com/6160205/224387243-ada2011e-a15e-4332-9415-2a95fb11f87a.jpg)

```py
# setup the display (this was tested on a CPB with TFT gizmo)
# display = ...
from adafruit_gizmo import tft_gizmo
display = tft_gizmo.TFT_Gizmo()

from adafruit_display_text_old import label as label0, bitmap_label as bitmap_label0
from adafruit_display_text import label, bitmap_label

import time
import displayio
import terminalio
import vectorio

# Make the display context
splash = displayio.Group(x=1, y=1, scale=2)
display.show(splash)
display.auto_refresh = False

color_palette = displayio.Palette(2)
color_palette[0] = 0x008000  # Bright Green
color_palette[1] = 0x808080 # 0xAA0088

lines = displayio.Group()
for num in range(21):
    y = 10 * num
    color = min(1, num % 5)
    lines.append(vectorio.Rectangle(pixel_shader=color_palette,
        width=display.width, height=1, x=0, y=y, color_index=color))
    lines.append(vectorio.Rectangle(pixel_shader=color_palette,
        width=1, height=display.height, x=y, y=0, color_index=color))

text_group = displayio.Group(scale=1, x=0, y=0)
def add_text(group=text_group, back_class=label, text="AB",
             border=0, x=0, y=0, anchor=(0,0), scale=1,
             direction="LTR", color=0xFF0000, back_color=0x606060
        ):
    position = (x, y)
    if isinstance(border, int):
        border = (border, border, border, border)
    if back_class:
        text_area2 = back_class.Label(
            terminalio.FONT, text=text, color=0xFFFFFF,
            anchor_point=anchor,
            anchored_position=position,
            padding_top = border[0],
            padding_bottom = border[1],
            padding_left = border[2],
            padding_right = border[3],
            background_color = back_color,
            scale = scale,
            label_direction=direction,
        )
        group.append(text_area2)
    text_area1 = bitmap_label.Label(
        terminalio.FONT, text=text, color=0xFFFFFF,
        anchor_point=anchor,
        anchored_position=position,
        padding_top = border[0],
        padding_bottom = border[1],
        padding_left = border[2],
        padding_right = border[3],
        background_color = color,
        scale = scale,
        label_direction=direction,
    )
    group.append(text_area1)

########################################################################
# directions: LTR / RTL / UPR / DWR

position_group = displayio.Group()
pp = {"group":position_group}
add_text(border=5, x=10, y=10, anchor=(0,0), **pp)
add_text(border=5, x=10, y=40, anchor=(0,0), direction="DWR", color=0x0000FF, **pp)
add_text(border=5, x=80, y=20, anchor=(1,1), direction="RTL", color=0x008000, **pp)
add_text(border=5, x=80, y=50, anchor=(1,1), direction="UPR", color=0xA08000, **pp)
add_text(border=0, x=40, y=10, anchor=(0,0), color=0xFF8080, **pp)
add_text(border=0, x=50, y=50, anchor=(1,1), color=0xFF8080, **pp)
text_group.append(position_group)

########################################################################

anchor = (0,0) # (1,1)
offset = 0     # 20

########################################################################

padding_group = displayio.Group(y=60 + offset)
parameters = {
    "group":padding_group,
    "direction":"DWR",
    "color":0x008000,
    "back_class":bitmap_label0,
    "back_color":0xFF0000,
    "anchor":anchor,
}
add_text(border=(5,0,0,0), x=10, y=0, text="TOP", **parameters)
add_text(border=(0,5,0,0), x=40, y=0, text="BTM", **parameters)
add_text(border=(0,0,5,0), x=70, y=0, text="LFT", **parameters)
add_text(border=(0,0,0,5), x=100, y=0, text="RGT", **parameters)
text_group.append(padding_group)

########################################################################

padding_group2 = displayio.Group(y=90 + offset)
parameters = {
    "group":padding_group2,
    "direction":"UPR",
    "color":0x008000,
    "back_class":bitmap_label0,
    "back_color":0xFF0000,
    "anchor":anchor,
}
add_text(border=(5,0,0,0), x=10, y=0, text="TOP", **parameters)
add_text(border=(0,5,0,0), x=40, y=0, text="BTM", **parameters)
add_text(border=(0,0,5,0), x=70, y=0, text="LFT", **parameters)
add_text(border=(0,0,0,5), x=100, y=0, text="RGT", **parameters)
text_group.append(padding_group2)

########################################################################

splash.append(text_group)
splash.append(lines)
display.refresh()

while True:
    pass
```