### PR TITLE
fixing label padding

### DIFF
--- a/adafruit_display_text/label.py
+++ b/adafruit_display_text/label.py
@@ -99,6 +99,7 @@ class Label(LabelBase):
         if text is not None:
             self._reset_text(str(text))
 
+    # pylint: disable=too-many-branches
     def _create_background_box(self, lines: int, y_offset: int) -> TileGrid:
         """Private Class function to create a background_box
         :param lines: int number of lines
@@ -114,16 +115,27 @@ class Label(LabelBase):
         else:  # draw a "loose" bounding box to include any ascenders/descenders.
             ascent, descent = self._ascent, self._descent
 
-            if self._label_direction in ("UPR", "DWR", "TTB"):
+            if self._label_direction in ("DWR", "UPR"):
                 box_height = (
-                    self._bounding_box[3] + self._padding_top + self._padding_bottom
+                    self._bounding_box[3] + self._padding_right + self._padding_left
                 )
-                x_box_offset = -self._padding_bottom
+                x_box_offset = -self._padding_left
                 box_width = (
                     (ascent + descent)
                     + int((lines - 1) * self._width * self._line_spacing)
-                    + self._padding_left
+                    + self._padding_top
+                    + self._padding_bottom
+                )
+            elif self._label_direction == "TTB":
+                box_height = (
+                    self._bounding_box[3] + self._padding_top + self._padding_bottom
+                )
+                x_box_offset = -self._padding_left
+                box_width = (
+                    (ascent + descent)
+                    + int((lines - 1) * self._height * self._line_spacing)
                     + self._padding_right
+                    + self._padding_left
                 )
             else:
                 box_width = (
@@ -137,23 +149,33 @@ class Label(LabelBase):
                     + self._padding_bottom
                 )
 
-            if self._base_alignment:
-                y_box_offset = -ascent - self._padding_top
+            if self._label_direction == "DWR":
+                padding_to_use = self._padding_bottom
+            elif self._label_direction == "TTB":
+                padding_to_use = self._padding_top
+                y_offset = 0
+                ascent = 0
             else:
-                y_box_offset = -ascent + y_offset - self._padding_top
+                padding_to_use = self._padding_top
+
+            if self._base_alignment:
+                y_box_offset = -ascent - padding_to_use
+            else:
+
+                y_box_offset = -ascent + y_offset - padding_to_use
 
         box_width = max(0, box_width)  # remove any negative values
         box_height = max(0, box_height)  # remove any negative values
 
         if self._label_direction == "UPR":
-            movx = left + x_box_offset
+            movx = y_box_offset
             movy = -box_height - x_box_offset
         elif self._label_direction == "DWR":
-            movx = left + x_box_offset
+            movx = y_box_offset
             movy = x_box_offset
         elif self._label_direction == "TTB":
-            movx = left + x_box_offset
-            movy = x_box_offset
+            movx = x_box_offset
+            movy = y_box_offset
         else:
             movx = left + x_box_offset
             movy = y_box_offset
@@ -168,6 +190,7 @@ class Label(LabelBase):
 
         return tile_grid
 
+    # pylint: enable=too-many-branches
     def _set_background_color(self, new_color: Optional[int]) -> None:
         """Private class function that allows updating the font box background color
 


### PR DESCRIPTION
closes #185 

Test code almost the same as previous PR by Neradoc

```python
# setup the display (this was tested on a CPB with TFT gizmo)
# display = ...

from adafruit_display_text import label, bitmap_ll
import time
import displayio
import terminalio
import vectorio
import board


display = board.DISPLAY
# Make the display context
splash = displayio.Group(x=1, y=1, scale=3)
display.show(splash)
display.auto_refresh = False

color_palette = displayio.Palette(3)
color_palette[0] = 0x008000  # Bright Green
color_palette[1] = 0x808080 # 0xAA0088
color_palette[2] = 0x000022

lines = displayio.Group()
for num in range(21):
    y = 10 * num
    if num % 5 == 0:
        COLOR = 0
    else:
        COLOR = 1
    lines.append(vectorio.Rectangle(pixel_shader=color_palette,
        width=display.width, height=1, x=0, y=y, color_index=COLOR,
    ))
    lines.append(vectorio.Rectangle(pixel_shader=color_palette,
        width=1, height=display.height, x=y, y=0, color_index=COLOR,
    ))

text_group = displayio.Group(scale=1, x=0, y=0)

def add_text(border=0, x=0, y=0, anchor=(0,0), scale=1, direction="LTR", text=None, color=None, touse=None
        ):
    position = (x, y)
    if isinstance(border, int):
        border = (border, border, border, border)
    if touse == "label":
        text_area1 = label.Label(
            terminalio.FONT, text=text, color=0xFFFFFF,
            anchor_point=anchor,
            anchored_position=position,
            padding_top = border[0],
            padding_bottom = border[1],
            padding_left = border[2],
            padding_right = border[3],
            background_color = color,
            scale = scale,
            label_direction=direction,
        )
        text_group.append(text_area1)

    if touse == "bmlabel":
        text_area2 = bitmap_ll.Label(
            terminalio.FONT, text=text, color=0x000000,
            anchor_point=anchor,
            anchored_position=position,
            padding_top = border[0],
            padding_bottom = border[1],
            padding_left = border[2],
            padding_right = border[3],
            background_color=0xFFFFFF,
            scale=scale,
            label_direction=direction,
        )
        text_group.append(text_area2)




direction = "DWR"
add_text(border=(5, 0, 0, 0), x=5, y=5, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(5, 0, 0, 0), x=5, y=10, direction=direction, text="J", touse="bmlabel")
add_text(border=(0, 5, 0, 0), x=5, y=17, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(0, 5, 0, 0), x=5, y=22, direction=direction, text="J", touse="bmlabel")
add_text(border=(0, 0, 5, 0), x=5, y=35, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(0, 0, 5, 0), x=15, y=35, direction=direction, text="J", touse="bmlabel")
add_text(border=(0, 0, 0, 5), x=5, y=45, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(0, 0, 0, 5), x=15, y=45, direction=direction, text="J", touse="bmlabel")
#
direction = "UPR"
add_text(border=(5, 0, 0, 0), x=30, y=5, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(5, 0, 0, 0), x=30, y=10, direction=direction, text="J", touse="bmlabel")
add_text(border=(0, 5, 0, 0), x=30, y=17, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(0, 5, 0, 0), x=30, y=22, direction=direction, text="J", touse="bmlabel")
add_text(border=(0, 0, 5, 0), x=30, y=35, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(0, 0, 5, 0), x=40, y=35, direction=direction, text="J", touse="bmlabel")
add_text(border=(0, 0, 0, 5), x=30, y=55, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(0, 0, 0, 5), x=40, y=55, direction=direction, text="J", touse="bmlabel")


direction = "TTB"
add_text(border=(5, 0, 0, 0), x=65, y=15, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(0, 5, 0, 0), x=65, y=35, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(0, 0, 5, 0), x=65, y=55, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(0, 0, 0, 5), x=65, y=75, direction=direction, text="J", color=0x440044, touse="label")


direction = "LTR"
add_text(border=(5, 0, 0, 0), x=90, y=5, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(5, 0, 0, 0), x=95, y=5, direction=direction, text="J", touse="bmlabel")
add_text(border=(0, 5, 0, 0), x=90, y=20, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(0, 5, 0, 0), x=95, y=20, direction=direction, text="J", touse="bmlabel")
add_text(border=(0, 0, 5, 0), x=90, y=38, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(0, 0, 5, 0), x=90, y=51, direction=direction, text="J", touse="bmlabel")
add_text(border=(0, 0, 0, 5), x=90, y=65, direction=direction, text="J", color=0x440044, touse="label")
add_text(border=(0, 0, 0, 5), x=90, y=78, direction=direction, text="J", touse="bmlabel")

splash.append(text_group)
splash.append(lines)
display.refresh()



```