### PR TITLE
override text property from parent on ScrollingLabel

### DIFF
--- a/adafruit_display_text/scrolling_label.py
+++ b/adafruit_display_text/scrolling_label.py
@@ -86,7 +86,7 @@ class ScrollingLabel(bitmap_label.Label):
         if force or self._last_animate_time + self.animate_time <= _now:
 
             if len(self.full_text) <= self.max_characters:
-                self.text = self.full_text
+                super()._set_text(self.full_text, self.scale)
                 self._last_animate_time = _now
                 return
 
@@ -106,8 +106,7 @@ class ScrollingLabel(bitmap_label.Label):
                 _showing_string = "{}{}".format(
                     _showing_string_start, _showing_string_end
                 )
-            self.text = _showing_string
-
+            super()._set_text(_showing_string, self.scale)
             self.current_index += 1
             self._last_animate_time = _now
 
@@ -144,3 +143,16 @@ class ScrollingLabel(bitmap_label.Label):
         self._full_text = new_text
         self.current_index = 0
         self.update()
+
+    @property
+    def text(self):
+        """The full text to be shown. If it's longer than ``max_characters`` then
+        scrolling will occur as needed.
+
+        :return str: The full text of this label.
+        """
+        return self.full_text
+
+    @text.setter
+    def text(self, new_text):
+        self.full_text = new_text


### PR DESCRIPTION
This resolves #182 

As was noted on a comment in the issue `full_text` was the property that was used to change the text rather than `text` like it is with BitmapLabel and Label. So the functionality to change text after creation does exist, but the property name used to do it is not the same as it is on the other Label types.

This was original done that way because I didn't know how to override parent properties while still being able to use the parent implementation of the property in some other parts of code. It turned out that we skirted around that issue by being able to call the internal `_set_text()` function directly rather than using the parents properties.

The change in this PR makes it so that `scrolling_lbl.text` will now function the same as `scrolling_lbl.full_text` which means it will change the text in the scrolling label as likely expected by users who try setting it.

