### PR TITLE
bitmaptools.blit refactor support

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -27,6 +27,7 @@ __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
 
 import displayio
+import bitmaptools
 from adafruit_display_text import LabelBase
 
 try:
@@ -481,6 +482,18 @@ class Label(LabelBase):
                 x2=x_2,
                 y2=y_2,
                 skip_index=skip_index,
+            )
+        elif hasattr(bitmaptools, "blit"):
+            bitmaptools.blit(
+                bitmap,
+                source_bitmap,
+                x,
+                y,
+                x1=x_1,
+                y1=y_1,
+                x2=x_2,
+                y2=y_2,
+                skip_source_index=skip_index,
             )
 
         else:  # perform pixel by pixel copy of the bitmap

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["displayio", "adafruit_bitmap_font", "fontio"]
+autodoc_mock_imports = ["displayio", "adafruit_bitmap_font", "fontio", "bitmaptools"]
 
 
 intersphinx_mapping = {


### PR DESCRIPTION
This adds support for the change this core pr: https://github.com/adafruit/circuitpython/pull/8136

There is still fallback logic so that devices that aren't on the same versions can still both work with the library