### PR TITLE
clamp x value to positive

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -441,7 +441,7 @@ class Label(LabelBase):
 
                     self._blit(
                         bitmap,
-                        xposition + my_glyph.dx,
+                        max(xposition + my_glyph.dx, 0),
                         y_blit_target,
                         my_glyph.bitmap,
                         x_1=glyph_offset_x,


### PR DESCRIPTION
resolves: #193 

Clamps x value to positive so that it will not attempt to blit out of bounds