### PR TITLE
chore: allow use of bitmap_label without bitmaptools

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -27,8 +27,13 @@ __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
 
 import displayio
-import bitmaptools
 from adafruit_display_text import LabelBase
+
+try:
+    import bitmaptools
+except ImportError:
+    # We have a slower fallback for bitmaptools
+    pass
 
 try:
     from typing import Optional, Tuple


### PR DESCRIPTION
in some cases, bitmaptools may not even be used - such as when displayio.Bitmap supports blit.  in others, the module can run without bitmaptools as it has a fallback which works even if it's slower

fixes #192 

tested by ensuring the circuitplayground express - which seems to omit `bitmaptools` - can still blit even if it's slow