### PR TITLE
Use adafruit_ticks.ticks_ms for scrolling_label animation

### DIFF
--- a/adafruit_display_text/scrolling_label.py
+++ b/adafruit_display_text/scrolling_label.py
@@ -26,7 +26,7 @@ Implementation Notes
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
 
-from adafruit_ticks import ticks_ms
+import adafruit_ticks
 from adafruit_display_text import bitmap_label
 
 try:
@@ -81,10 +81,10 @@ class ScrollingLabel(bitmap_label.Label):
          Default is False.
         :return: None
         """
-        _now = ticks_ms()
-        if _now < self._last_animate_time:  # ticks_ms has rolled over
-            self._last_animate_time = _now
-        if force or self._last_animate_time + (self.animate_time * 1000) <= _now:
+        _now = adafruit_ticks.ticks_ms()
+        if force or adafruit_ticks.ticks_less(
+            self._last_animate_time + int(self.animate_time * 1000), _now
+        ):
             if len(self.full_text) <= self.max_characters:
                 super()._set_text(self.full_text, self.scale)
                 self._last_animate_time = _now

--- a/adafruit_display_text/scrolling_label.py
+++ b/adafruit_display_text/scrolling_label.py
@@ -26,7 +26,7 @@ Implementation Notes
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
 
-import time
+from supervisor import ticks_ms
 from adafruit_display_text import bitmap_label
 
 try:
@@ -81,8 +81,10 @@ class ScrollingLabel(bitmap_label.Label):
          Default is False.
         :return: None
         """
-        _now = time.monotonic()
-        if force or self._last_animate_time + self.animate_time <= _now:
+        _now = ticks_ms()
+        if _now < self._last_animate_time:  # ticks_ms has rolled over
+            self._last_animate_time = _now
+        if force or self._last_animate_time + (self.animate_time*1000) <= _now:
             if len(self.full_text) <= self.max_characters:
                 super()._set_text(self.full_text, self.scale)
                 self._last_animate_time = _now

--- a/adafruit_display_text/scrolling_label.py
+++ b/adafruit_display_text/scrolling_label.py
@@ -26,7 +26,7 @@ Implementation Notes
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Display_Text.git"
 
-from supervisor import ticks_ms
+from adafruit_ticks import ticks_ms
 from adafruit_display_text import bitmap_label
 
 try:

--- a/adafruit_display_text/scrolling_label.py
+++ b/adafruit_display_text/scrolling_label.py
@@ -84,7 +84,7 @@ class ScrollingLabel(bitmap_label.Label):
         _now = ticks_ms()
         if _now < self._last_animate_time:  # ticks_ms has rolled over
             self._last_animate_time = _now
-        if force or self._last_animate_time + (self.animate_time*1000) <= _now:
+        if force or self._last_animate_time + (self.animate_time * 1000) <= _now:
             if len(self.full_text) <= self.max_characters:
                 super()._set_text(self.full_text, self.scale)
                 self._last_animate_time = _now

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,13 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["displayio", "adafruit_bitmap_font", "fontio", "bitmaptools","supervisor"]
+autodoc_mock_imports = [
+    "displayio",
+    "adafruit_bitmap_font",
+    "fontio",
+    "bitmaptools",
+    "supervisor",
+]
 
 
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["displayio", "adafruit_bitmap_font", "fontio", "bitmaptools"]
+autodoc_mock_imports = ["displayio", "adafruit_bitmap_font", "fontio", "bitmaptools","supervisor"]
 
 
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,6 @@ autodoc_mock_imports = [
     "adafruit_bitmap_font",
     "fontio",
     "bitmaptools",
-    "supervisor",
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 Adafruit-Blinka-displayio>=0.10.2
 Adafruit-Blinka
 adafruit-circuitpython-bitmap-font
+adafruit-circuitpython-ticks


### PR DESCRIPTION
As described in adafruit/circuitpython#5411 time.monotonic loses precision over time, which eventually causes the scrolling_label animation to occur every time an update method is called. This can result in the scrolling text suddenly speeding up dramatically.

This PR uses supervisor.ticks_ms and adds a bit of logic to watch for the value rolling over instead of time.monotonic() which should resolve the issue. As mentioned  by Dan in the referenced issue, another option would be to use time.monotonic_ns and similarly watch for the rollover, however apparently not all boards support the monotonic_ns method.