### PR TITLE
fix bmp_lbl for ascenders and descenders

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -292,15 +292,18 @@ class Label(LabelBase):
     def _text_bounding_box(
         self, text: str, font: FontProtocol
     ) -> Tuple[int, int, int, int, int, int]:
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-locals,too-many-branches
 
-        ascender_max, descender_max = self._ascent, self._descent
+        bbox = font.get_bounding_box()
+        if len(bbox) == 4:
+            ascender_max, descender_max = bbox[1], -bbox[3]
+        else:
+            ascender_max, descender_max = self._ascent, self._descent
 
         lines = 1
 
-        xposition = (
-            x_start
-        ) = yposition = y_start = 0  # starting x and y position (left margin)
+        # starting x and y position (left margin)
+        xposition = x_start = yposition = y_start = 0
 
         left = None
         right = x_start


### PR DESCRIPTION
@ladyada 

Resolves: #201 

I tested on PyPortal Titano with the font specified in the issue and confirmed with this change bitmap label no longer cuts off the top and bot of ascenders and descenders. 

I looked into the position offset between Label and Bitmap label mentioned in the issue as well. The root cause of that the code using anchor point and anchor position which take into account the width and height of the bounding box. It turns out that Label and Bitmap label differ in the size that they come up for the height when `background_tight=False` (which is the default value). That difference in size results in a difference of location when placed with the relative anchors. If you use `background_tight=True` for both types then the height will end up the same and thus placement will also match. I think that is worthy of it's own separate issue as it seems unrelated specifically to the cutting off of ascenders and descenders.