### PR TITLE
Optimize LabelBase text setter

### DIFF
--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -413,6 +413,8 @@ class LabelBase(Group):
 
     @text.setter  # Cannot set color or background color with text setter, use separate setter
     def text(self, new_text: str) -> None:
+        if new_text == self._text:
+            return
         self._set_text(new_text, self.scale)
 
     @property


### PR DESCRIPTION
Added a check to skip redundant `_set_text` calls if the text hasn't changed.