### PR TITLE
Managing addition of space at end of text

### DIFF
--- a/adafruit_display_text/scrolling_label.py
+++ b/adafruit_display_text/scrolling_label.py
@@ -67,7 +67,7 @@ class ScrollingLabel(bitmap_label.Label):
         self._last_animate_time = -1
         self._max_characters = max_characters
 
-        if text and text[-1] != " " and len(text) > max_characters::
+        if text and text[-1] != " " and len(text) > max_characters:
             text = f"{text} "
         self._full_text = text
 

--- a/adafruit_display_text/scrolling_label.py
+++ b/adafruit_display_text/scrolling_label.py
@@ -65,7 +65,7 @@ class ScrollingLabel(bitmap_label.Label):
         self.animate_time = animate_time
         self._current_index = current_index
         self._last_animate_time = -1
-        self.max_characters = max_characters
+        self._max_characters = max_characters
 
         if text and text[-1] != " ":
             text = f"{text} "
@@ -137,7 +137,7 @@ class ScrollingLabel(bitmap_label.Label):
 
     @full_text.setter
     def full_text(self, new_text: str) -> None:
-        if new_text and new_text[-1] != " ":
+        if new_text and new_text[-1] != " " and len(new_text) > self.max_characters:
             new_text = f"{new_text} "
         if new_text != self._full_text:
             self._full_text = new_text
@@ -156,3 +156,21 @@ class ScrollingLabel(bitmap_label.Label):
     @text.setter
     def text(self, new_text):
         self.full_text = new_text
+    
+    @property
+    def max_characters(self):
+        """The maximum number of characters to display on screen.
+
+        :return int: The maximum character length of this label.
+        """
+        return self._max_characters
+
+    @max_characters.setter
+    def max_characters(self, new_max_characters):
+        """Recalculate the full text based on the new max characters.
+           This is necessary to correctly handle the potential space at the end of
+           the text.
+        """
+        if new_max_characters != self._max_characters:
+            self._max_characters = new_max_characters
+            self.full_text = self.full_text

--- a/adafruit_display_text/scrolling_label.py
+++ b/adafruit_display_text/scrolling_label.py
@@ -168,7 +168,7 @@ class ScrollingLabel(bitmap_label.Label):
     @max_characters.setter
     def max_characters(self, new_max_characters):
         """Recalculate the full text based on the new max characters.
-        
+
         This is necessary to correctly handle the potential space at the end of
         the text.
         """

--- a/adafruit_display_text/scrolling_label.py
+++ b/adafruit_display_text/scrolling_label.py
@@ -67,7 +67,7 @@ class ScrollingLabel(bitmap_label.Label):
         self._last_animate_time = -1
         self._max_characters = max_characters
 
-        if text and text[-1] != " ":
+        if text and text[-1] != " " and len(text) > max_characters::
             text = f"{text} "
         self._full_text = text
 

--- a/adafruit_display_text/scrolling_label.py
+++ b/adafruit_display_text/scrolling_label.py
@@ -71,7 +71,7 @@ class ScrollingLabel(bitmap_label.Label):
             text = f"{text} "
         self._full_text = text
 
-        self.update()
+        self.update(True)
 
     def update(self, force: bool = False) -> None:
         """Attempt to update the display. If ``animate_time`` has elapsed since

--- a/adafruit_display_text/scrolling_label.py
+++ b/adafruit_display_text/scrolling_label.py
@@ -156,7 +156,7 @@ class ScrollingLabel(bitmap_label.Label):
     @text.setter
     def text(self, new_text):
         self.full_text = new_text
-    
+
     @property
     def max_characters(self):
         """The maximum number of characters to display on screen.

--- a/adafruit_display_text/scrolling_label.py
+++ b/adafruit_display_text/scrolling_label.py
@@ -168,8 +168,9 @@ class ScrollingLabel(bitmap_label.Label):
     @max_characters.setter
     def max_characters(self, new_max_characters):
         """Recalculate the full text based on the new max characters.
-           This is necessary to correctly handle the potential space at the end of
-           the text.
+        
+        This is necessary to correctly handle the potential space at the end of
+        the text.
         """
         if new_max_characters != self._max_characters:
             self._max_characters = new_max_characters


### PR DESCRIPTION
Wrapping max_characters in properties and checking for length of text before adding a space to full_text.

This addresses the situation where the text is shorter or equal to the max_characters, which would add a space when shorter or start scrolling unnecessarily when equal to.  Shorter isn't a big deal when left aligned, but it is noticeable when center or right aligned.