### PR TITLE
fix anchored positioning for TextBox

### DIFF
--- a/adafruit_display_text/text_box.py
+++ b/adafruit_display_text/text_box.py
@@ -264,7 +264,7 @@ class TextBox(bitmap_label.Label):
             # Calculate both "tight" and "loose" bounding box dimensions to match label for
             # anchor_position calculations
             (
-                box_x,
+                box_x,  # noqa: F841, var assigned not used
                 tight_box_y,
                 x_offset,
                 tight_y_offset,
@@ -288,8 +288,6 @@ class TextBox(bitmap_label.Label):
                 y_offset = loose_y_offset
 
             # Calculate the background size including padding
-            tight_box_x = box_x
-            box_x = box_x + self._padding_left + self._padding_right
             box_y = box_y + self._padding_top + self._padding_bottom
 
             if self.dynamic_height:
@@ -343,8 +341,8 @@ class TextBox(bitmap_label.Label):
             self._bounding_box = (
                 self._tilegrid.x + self._padding_left,
                 self._tilegrid.y + self._padding_top,
-                tight_box_x,
-                tight_box_y,
+                self.width,
+                self.height,
             )
 
         if (

--- a/examples/display_text_text_box_simpletest.py
+++ b/examples/display_text_text_box_simpletest.py
@@ -7,6 +7,7 @@ import terminalio
 
 from adafruit_display_text.text_box import TextBox
 
+display = board.DISPLAY
 main_group = displayio.Group()
 
 left_text = ("Left left left left " * 2).rstrip()
@@ -21,8 +22,8 @@ left_text_area = TextBox(
     scale=1,
 )
 
-left_text_area.x = 10
-left_text_area.y = 10
+left_text_area.anchor_point = (0, 0)
+left_text_area.anchored_position = (0, 0)
 main_group.append(left_text_area)
 
 
@@ -38,8 +39,8 @@ center_text_area = TextBox(
     scale=1,
 )
 
-center_text_area.x = 10
-center_text_area.y = 10 + left_text_area.height + 10
+center_text_area.anchor_point = (0.5, 0.5)
+center_text_area.anchored_position = (display.width // 2, display.height // 2)
 main_group.append(center_text_area)
 
 
@@ -55,8 +56,8 @@ right_text_area = TextBox(
     scale=1,
 )
 
-right_text_area.x = 10
-right_text_area.y = center_text_area.y + center_text_area.height + 10
+right_text_area.anchor_point = (1.0, 1.0)
+right_text_area.anchored_position = (display.width, display.height)
 main_group.append(right_text_area)
 
 board.DISPLAY.root_group = main_group


### PR DESCRIPTION
Resolves: #221 

`_reset_text()` was erroneously setting the `self._bounding_box` width to the value calculated dynamically instead of the user specified width value.  Which then caused the anchoring math to get thrown off. Height probably suffered from the same bug, but it would only matter if you were not using dynamic height.

This fixes it by setting the width and height to user specified values. I've also updated the TextBox example script to make use of anchor_point and anchored_position which is what I used for testing the fix.



