### PR TITLE
skip updating text if it's the same in bitmap_label

### DIFF
--- a/adafruit_display_text/bitmap_label.py
+++ b/adafruit_display_text/bitmap_label.py
@@ -1060,6 +1060,8 @@ class Label(LabelBase):
 
     @text.setter
     def text(self, new_text):
+        if new_text == self.full_text:
+            return
         self.full_text = new_text
         self.update(True)
 


### PR DESCRIPTION
This fixes a regression that I think was introduced during the 4.0 refactor that combined outline, scrolling, and accent into bitmap_label.

bitmap_label used to defer to LabelBase.text setter property which has a check to ignore values that are the same as the current text here: https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/blob/438f8c7a9b796c5bd039a83d3e577fbf2bbbb3d2/adafruit_display_text/__init__.py#L450-L451

The refactored version lacked that same check, I noticed it while working on my current project. When the text gets updated over and over in a tight loop it causes it to flicker on the display. 

Resolves it by using the same logic inside bitmap label text property setter.