### PR TITLE
fix: avoid orphaning a final wrapped character

### DIFF
--- a/adafruit_display_text/__init__.py
+++ b/adafruit_display_text/__init__.py
@@ -119,18 +119,19 @@ def wrap_text_to_pixels(
             cur_part = ""
 
             if wwidth > max_width:
-                for char in word:
+                for char_offset, char in enumerate(word):
                     if newline:
                         extraspace = 0
                         leadchar = ""
                     else:
                         extraspace = swidth
                         leadchar = " "
+                    hyphen_width = measure("-") if char_offset < len(word) - 1 else 0
                     if (
                         measure("".join(partial))
                         + measure(cur_part)
                         + measure(char)
-                        + measure("-")
+                        + hyphen_width
                         + extraspace
                         > max_width
                     ):


### PR DESCRIPTION
Fixes #226

When splitting an overlong word, `wrap_text_to_pixels()` always reserved space for a continuation hyphen before testing the next character. On the final character, that could force a character that otherwise fit onto a new line and leave the previous line ending in an unnecessary hyphen.

This reserves hyphen width only when characters remain after the one being tested. True continuations still keep their hyphen, while the final character can use the available line width.

Regression example at width 4:

- before: `['abc-', 'def-', 'g']`
- after: `['abc-', 'defg']`

Verification:

- boundary regression matrix covering exact fit, normal continuation, and the orphaned-final-character case
- `python -m compileall -q adafruit_display_text`
- `ruff format --check adafruit_display_text/__init__.py`
- `ruff check adafruit_display_text/__init__.py`
- clean sdist and wheel build

